### PR TITLE
Add custom cookiebanner component

### DIFF
--- a/enhanceApp.js
+++ b/enhanceApp.js
@@ -1,10 +1,9 @@
 // import pageComponents from "@internal/page-components";
-import { Tooltip, CookieBanner } from "@cosmos-ui/vue";
+import { Tooltip } from "@cosmos-ui/vue";
 import MarkdownIt from "markdown-it";
 
 export default ({ Vue }) => {
   Vue.component("df", Tooltip);
-  Vue.component("df", CookieBanner);
   // for (const [name, component] of Object.entries(pageComponents)) {
   //   Vue.component(name, component);
   // }

--- a/layouts/GlobalLayout.vue
+++ b/layouts/GlobalLayout.vue
@@ -1,5 +1,6 @@
 <template lang="pug">
   div
+    cookie-banner
     .layout
       .layout__sidebar
         tm-sidebar-content(:value="tree" :tree="directoryTree")
@@ -254,8 +255,10 @@ import {
   map
 } from "lodash";
 import hotkeys from "hotkeys-js";
+import { CookieBanner } from "@cosmos-ui/vue";
 
 export default {
+  components: { CookieBanner, },
   data: function() {
     return {
       sidebarVisible: null,


### PR DESCRIPTION
I figured to add `cookie-banner` to all of the `vuepress-theme-cosmos` built Vuepress. I could just call the CookieBanner component in this repo. Feel free to edit this @fadeev 