### PR TITLE
Fix high severity dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2045,114 +2045,10 @@
         "string-width": "^3.0.0"
       }
     },
-    "ansi-bgblack": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgblack/-/ansi-bgblack-0.1.1.tgz",
-      "integrity": "sha1-poulAHiHcBtqr74/oNrf36juPKI=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgblue": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgblue/-/ansi-bgblue-0.1.1.tgz",
-      "integrity": "sha1-Z73ATtybm1J4lp2hlt6j11yMNhM=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgcyan": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgcyan/-/ansi-bgcyan-0.1.1.tgz",
-      "integrity": "sha1-WEiUJWAL3p9VBwaN2Wnr/bUP52g=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bggreen": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bggreen/-/ansi-bggreen-0.1.1.tgz",
-      "integrity": "sha1-TjGRJIUplD9DIelr8THRwTgWr0k=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgmagenta": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgmagenta/-/ansi-bgmagenta-0.1.1.tgz",
-      "integrity": "sha1-myhDLAduqpmUGGcqPvvhk5HCx6E=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgred": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgred/-/ansi-bgred-0.1.1.tgz",
-      "integrity": "sha1-p2+Sg4OCukMpCmwXeEJPmE1vEEE=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgwhite": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgwhite/-/ansi-bgwhite-0.1.1.tgz",
-      "integrity": "sha1-ZQRlE3elim7OzQMxmU5IAljhG6g=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgyellow": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgyellow/-/ansi-bgyellow-0.1.1.tgz",
-      "integrity": "sha1-w/4usIzUdmSAKeaHTRWgs49h1E8=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-black": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-black/-/ansi-black-0.1.1.tgz",
-      "integrity": "sha1-9hheiJNgslRaHsUMC/Bj/EMDJFM=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-blue": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-blue/-/ansi-blue-0.1.1.tgz",
-      "integrity": "sha1-FbgEmQ6S/JyoxUds6PaZd3wh7b8=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bold": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bold/-/ansi-bold-0.1.1.tgz",
-      "integrity": "sha1-PmOVCvWswq4uZw5vZ96xFdGl9QU=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
       "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
-    },
-    "ansi-cyan": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-dim": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-dim/-/ansi-dim-0.1.1.tgz",
-      "integrity": "sha1-QN5MYDqoCG2Oeoa4/5mNXDbu/Ww=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
     },
     "ansi-escapes": {
       "version": "4.3.1",
@@ -2162,95 +2058,15 @@
         "type-fest": "^0.11.0"
       }
     },
-    "ansi-gray": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-green": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-      "integrity": "sha1-il2al55FjVfEDjNYCzc5C44Q0Pc=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-grey": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-grey/-/ansi-grey-0.1.1.tgz",
-      "integrity": "sha1-WdmLasK6GfilF5jphT+6eDOaM8E=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-hidden": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-hidden/-/ansi-hidden-0.1.1.tgz",
-      "integrity": "sha1-7WpMSY0rt8uyidvyqNHcyFZ/rg8=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
     "ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
-    "ansi-inverse": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-inverse/-/ansi-inverse-0.1.1.tgz",
-      "integrity": "sha1-tq9Fgm/oJr+1KKbHmIV5Q1XM0mk=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-italic": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-italic/-/ansi-italic-0.1.1.tgz",
-      "integrity": "sha1-EEdDRj9iXBQqA2c5z4XtpoiYbyM=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-magenta": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-magenta/-/ansi-magenta-0.1.1.tgz",
-      "integrity": "sha1-BjtboW+z8j4c/aKwfAqJ3hHkMK4=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-red": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-reset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-reset/-/ansi-reset-0.1.1.tgz",
-      "integrity": "sha1-5+cSksPH3c1NYu9KbHwFmAkRw7c=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-strikethrough": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-strikethrough/-/ansi-strikethrough-0.1.1.tgz",
-      "integrity": "sha1-2Eh3FAss/wfRyT685pkE9oiF5Wg=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -2258,35 +2074,6 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
         "color-convert": "^1.9.0"
-      }
-    },
-    "ansi-underline": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-underline/-/ansi-underline-0.1.1.tgz",
-      "integrity": "sha1-38kg9Ml7WXfqFi34/7mIMIqqcaQ=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-white": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-white/-/ansi-white-0.1.1.tgz",
-      "integrity": "sha1-nHe3wZPF7pkuYBHTbsTJIbRXiUQ=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-wrap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
-    },
-    "ansi-yellow": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-yellow/-/ansi-yellow-0.1.1.tgz",
-      "integrity": "sha1-y5NW8vRscy8OMZnmEClVp32oPB0=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
       }
     },
     "anymatch": {
@@ -2331,22 +2118,6 @@
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
-    "arr-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
-      "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
-      "requires": {
-        "make-iterator": "^1.0.0"
-      }
-    },
-    "arr-pluck": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/arr-pluck/-/arr-pluck-0.1.0.tgz",
-      "integrity": "sha1-+K1tcI+HkAiB4jr9gw1SKQp2Z3U=",
-      "requires": {
-        "arr-map": "^2.0.0"
-      }
-    },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
@@ -2356,23 +2127,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
       "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
-    },
-    "array-sort": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.4.tgz",
-      "integrity": "sha512-BNcM+RXxndPxiZ2rd76k6nyQLRZr2/B/sdi8pQ+Joafr5AH279L40dfokSUTp8O+AaqYjXWhblBWa2st2nc4fQ==",
-      "requires": {
-        "default-compare": "^1.0.0",
-        "get-value": "^2.0.6",
-        "kind-of": "^5.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
     },
     "array-union": {
       "version": "1.0.2",
@@ -2391,14 +2145,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-    },
-    "arrayify-compact": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/arrayify-compact/-/arrayify-compact-0.2.0.tgz",
-      "integrity": "sha1-RZFw4VXKErtRRISDnJ1xUHyA7E0=",
-      "requires": {
-        "arr-flatten": "^1.0.1"
-      }
     },
     "asap": {
       "version": "2.0.6",
@@ -2427,213 +2173,6 @@
           "version": "4.11.9",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        }
-      }
-    },
-    "assemble-core": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/assemble-core/-/assemble-core-0.25.0.tgz",
-      "integrity": "sha1-ZZF7/K+c1rFNm5HQMaDdmar0OWQ=",
-      "requires": {
-        "assemble-fs": "^0.6.0",
-        "assemble-render-file": "^0.7.1",
-        "assemble-streams": "^0.6.0",
-        "base-task": "^0.6.1",
-        "define-property": "^0.2.5",
-        "lazy-cache": "^2.0.1",
-        "templates": "^0.24.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "assemble-fs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/assemble-fs/-/assemble-fs-0.6.0.tgz",
-      "integrity": "sha1-uky+t0tdG97m1SipZa07fZbe8Og=",
-      "requires": {
-        "assemble-handle": "^0.1.2",
-        "extend-shallow": "^2.0.1",
-        "is-valid-app": "^0.2.0",
-        "lazy-cache": "^2.0.1",
-        "stream-combiner": "^0.2.2",
-        "through2": "^2.0.1",
-        "vinyl-fs": "^2.4.3"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "assemble-handle": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/assemble-handle/-/assemble-handle-0.1.4.tgz",
-      "integrity": "sha1-6De1uyPnXJsFJX2AfhYvaSzOIW4=",
-      "requires": {
-        "through2": "^2.0.3"
-      }
-    },
-    "assemble-loader": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/assemble-loader/-/assemble-loader-0.6.1.tgz",
-      "integrity": "sha1-0GmqZBhOFzKEP+HsGAghI1dpVdg=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "file-contents": "^0.2.4",
-        "fs-exists-sync": "^0.1.0",
-        "has-glob": "^0.1.1",
-        "is-registered": "^0.1.5",
-        "is-valid-glob": "^0.3.0",
-        "is-valid-instance": "^0.1.0",
-        "isobject": "^2.1.0",
-        "lazy-cache": "^2.0.1",
-        "load-templates": "^0.11.3"
-      },
-      "dependencies": {
-        "is-valid-instance": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
-          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
-          "requires": {
-            "isobject": "^2.1.0",
-            "pascalcase": "^0.1.1"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "assemble-render-file": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/assemble-render-file/-/assemble-render-file-0.7.2.tgz",
-      "integrity": "sha1-g6qV9e131ctK6oq8dPIkoVRVccY=",
-      "requires": {
-        "debug": "^2.2.0",
-        "is-valid-app": "^0.1.2",
-        "lazy-cache": "^2.0.1",
-        "mixin-deep": "^1.1.3",
-        "through2": "^2.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "is-valid-app": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
-          "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
-          "requires": {
-            "debug": "^2.2.0",
-            "is-registered": "^0.1.5",
-            "is-valid-instance": "^0.1.0",
-            "lazy-cache": "^2.0.1"
-          }
-        },
-        "is-valid-instance": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
-          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
-          "requires": {
-            "isobject": "^2.1.0",
-            "pascalcase": "^0.1.1"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "assemble-streams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/assemble-streams/-/assemble-streams-0.6.0.tgz",
-      "integrity": "sha1-kOkhaoNpltJoNwvtrHG7MdjJq18=",
-      "requires": {
-        "assemble-handle": "^0.1.2",
-        "is-registered": "^0.1.4",
-        "is-valid-instance": "^0.1.0",
-        "lazy-cache": "^2.0.1",
-        "match-file": "^0.2.0",
-        "src-stream": "^0.1.1",
-        "through2": "^2.0.1"
-      },
-      "dependencies": {
-        "is-valid-instance": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
-          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
-          "requires": {
-            "isobject": "^2.1.0",
-            "pascalcase": "^0.1.1"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
         }
       }
     },
@@ -2666,28 +2205,6 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
-    "assign-deep": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/assign-deep/-/assign-deep-0.4.8.tgz",
-      "integrity": "sha512-uxqXJCnNZDEjPnsaLKVzmh/ST5+Pqoz0wi06HDfHKx1ASNpSbbvz2qW2Gl8ZyHwr5jnm11X2S5eMQaP1lMZmCg==",
-      "requires": {
-        "assign-symbols": "^0.1.1",
-        "is-primitive": "^2.0.0",
-        "kind-of": "^5.0.2"
-      },
-      "dependencies": {
-        "assign-symbols": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-0.1.1.tgz",
-          "integrity": "sha1-ywJZRO9OyKNpPwhunhEsdOOg/tk="
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -2701,84 +2218,15 @@
         "lodash": "^4.17.14"
       }
     },
-    "async-array-reduce": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz",
-      "integrity": "sha1-yL4BCitc0A3qlsgRFgNGk9/dgtE="
-    },
-    "async-done": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
-      "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.2",
-        "process-nextick-args": "^2.0.0",
-        "stream-exhaust": "^1.0.1"
-      }
-    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
     },
-    "async-each-series": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
-      "integrity": "sha1-9C/YFV048hpbjqB8KOBj7RcAsTg="
-    },
-    "async-helpers": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/async-helpers/-/async-helpers-0.3.17.tgz",
-      "integrity": "sha512-LfgCyvmK6ZiC7pyqOgli2zfkWL4HYbEb+HXvGgdmqVBgsOOtQz5rSF8Ii/H/1cNNtrfj1KsdZE/lUMeIY3Qcwg==",
-      "requires": {
-        "co": "^4.6.0",
-        "kind-of": "^6.0.0"
-      }
-    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
-    },
-    "async-settle": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-0.2.1.tgz",
-      "integrity": "sha1-dnRi1XOACNx16sQkYiNSjyE3E5Y=",
-      "requires": {
-        "async-done": "^0.4.0"
-      },
-      "dependencies": {
-        "async-done": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/async-done/-/async-done-0.4.0.tgz",
-          "integrity": "sha1-q4BT9fYikPi/xY83zZtzBwszB7k=",
-          "requires": {
-            "end-of-stream": "^0.1.4",
-            "next-tick": "^0.2.2",
-            "once": "^1.3.0",
-            "stream-exhaust": "^1.0.0"
-          }
-        },
-        "end-of-stream": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-          "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
-          "requires": {
-            "once": "~1.3.0"
-          },
-          "dependencies": {
-            "once": {
-              "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-              "requires": {
-                "wrappy": "1"
-              }
-            }
-          }
-        }
-      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2875,22 +2323,6 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
-    "bach": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/bach/-/bach-0.5.0.tgz",
-      "integrity": "sha1-P/pqN0F3PrwNJL5f2kvF6FtbHaE=",
-      "requires": {
-        "async-done": "^1.1.1",
-        "async-settle": "^0.2.1",
-        "lodash.filter": "^4.1.0",
-        "lodash.flatten": "^4.0.0",
-        "lodash.foreach": "^4.0.0",
-        "lodash.initial": "^4.0.1",
-        "lodash.last": "^3.0.0",
-        "lodash.map": "^4.1.0",
-        "now-and-later": "0.0.6"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2942,1606 +2374,6 @@
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
-          }
-        }
-      }
-    },
-    "base-argv": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/base-argv/-/base-argv-0.4.5.tgz",
-      "integrity": "sha1-BalXHNwnaUDeGW/8h07uuJnLED0=",
-      "requires": {
-        "arr-diff": "^2.0.0",
-        "arr-union": "^3.1.0",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "expand-args": "^0.4.1",
-        "extend-shallow": "^2.0.1",
-        "lazy-cache": "^1.0.3"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-cli": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/base-cli/-/base-cli-0.5.0.tgz",
-      "integrity": "sha1-U+Zdjg9bKKoRBo/sjdTpXXLvPOg=",
-      "requires": {
-        "base-argv": "^0.4.2",
-        "base-config": "^0.5.2"
-      }
-    },
-    "base-cli-process": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/base-cli-process/-/base-cli-process-0.1.19.tgz",
-      "integrity": "sha1-Mg08gVTfcQltSBgY52/m1+R5NjY=",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "arrayify-compact": "^0.2.0",
-        "base-cli": "^0.5.0",
-        "base-cli-schema": "^0.1.19",
-        "base-config-process": "^0.1.9",
-        "base-cwd": "^0.3.4",
-        "base-option": "^0.8.4",
-        "base-pkg": "^0.2.4",
-        "debug": "^2.6.2",
-        "export-files": "^2.1.1",
-        "fs-exists-sync": "^0.1.0",
-        "is-valid-app": "^0.2.1",
-        "kind-of": "^3.1.0",
-        "lazy-cache": "^2.0.2",
-        "log-utils": "^0.2.1",
-        "merge-deep": "^3.0.0",
-        "mixin-deep": "^1.2.0",
-        "object.pick": "^1.2.0",
-        "pad-right": "^0.2.2",
-        "union-value": "^1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-cli-schema": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/base-cli-schema/-/base-cli-schema-0.1.19.tgz",
-      "integrity": "sha1-gfQYL0zwu4NnHxF2PknLBbkugkE=",
-      "requires": {
-        "arr-flatten": "^1.0.1",
-        "array-unique": "^0.2.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "export-files": "^2.1.1",
-        "extend-shallow": "^2.0.1",
-        "falsey": "^0.3.0",
-        "fs-exists-sync": "^0.1.0",
-        "has-glob": "^0.1.1",
-        "has-value": "^0.3.1",
-        "kind-of": "^3.0.3",
-        "lazy-cache": "^2.0.1",
-        "map-schema": "^0.2.3",
-        "merge-deep": "^3.0.0",
-        "mixin-deep": "^1.1.3",
-        "resolve": "^1.1.7",
-        "tableize-object": "^0.1.0"
-      },
-      "dependencies": {
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-compose": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/base-compose/-/base-compose-0.2.1.tgz",
-      "integrity": "sha1-reSal/WiRIvVa8s0C090aMb74tc=",
-      "requires": {
-        "copy-task": "^0.1.0",
-        "lazy-cache": "^2.0.1",
-        "mixin-deep": "^1.1.3"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-config": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/base-config/-/base-config-0.5.2.tgz",
-      "integrity": "sha1-q2A8AdExWL4uYux3/7Ix4o9Ijh8=",
-      "requires": {
-        "isobject": "^2.0.0",
-        "lazy-cache": "^1.0.3",
-        "map-config": "^0.5.0",
-        "resolve-dir": "^0.1.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
-    "base-config-process": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/base-config-process/-/base-config-process-0.1.9.tgz",
-      "integrity": "sha1-imOmGYnuY1UMyM/cP2wCdf2gtG4=",
-      "requires": {
-        "base-config": "^0.5.2",
-        "base-config-schema": "^0.1.18",
-        "base-cwd": "^0.3.4",
-        "base-option": "^0.8.4",
-        "debug": "^2.2.0",
-        "export-files": "^2.1.1",
-        "is-valid-app": "^0.2.0",
-        "lazy-cache": "^2.0.1",
-        "micromatch": "^2.3.10",
-        "mixin-deep": "^1.1.3"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
-      }
-    },
-    "base-config-schema": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/base-config-schema/-/base-config-schema-0.1.24.tgz",
-      "integrity": "sha1-T74UvsVtwa7ef+3QaSjpGfhyH6k=",
-      "requires": {
-        "arr-flatten": "^1.0.3",
-        "array-unique": "^0.3.2",
-        "base-pkg": "^0.2.4",
-        "camel-case": "^3.0.0",
-        "debug": "^2.6.6",
-        "define-property": "^1.0.0",
-        "export-files": "^2.1.1",
-        "extend-shallow": "^2.0.1",
-        "has-glob": "^1.0.0",
-        "has-value": "^0.3.1",
-        "inflection": "^1.12.0",
-        "kind-of": "^3.2.0",
-        "lazy-cache": "^2.0.2",
-        "load-templates": "^1.0.2",
-        "map-schema": "^0.2.4",
-        "matched": "^0.4.4",
-        "mixin-deep": "^1.2.0",
-        "resolve": "^1.3.3"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "file-contents": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/file-contents/-/file-contents-1.0.1.tgz",
-          "integrity": "sha1-ryW7/T00RjhPrYBmSdiAi8/uHsg=",
-          "requires": {
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "is-buffer": "^1.1.4",
-            "kind-of": "^3.1.0",
-            "lazy-cache": "^2.0.2",
-            "strip-bom-buffer": "^0.1.1",
-            "strip-bom-string": "^0.1.2",
-            "through2": "^2.0.3"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "requires": {
-                "kind-of": "^3.0.2"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "requires": {
-                "kind-of": "^3.0.2"
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "5.1.0",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-                }
-              }
-            }
-          }
-        },
-        "has-glob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
-          "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
-          "requires": {
-            "is-glob": "^3.0.0"
-          }
-        },
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.3",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-              "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.3",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-              "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.3",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-              "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-            }
-          }
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "load-templates": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/load-templates/-/load-templates-1.0.2.tgz",
-          "integrity": "sha1-CfOOlcjvS/t4W9f8qOv9MrIwvIc=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "file-contents": "^1.0.0",
-            "glob-parent": "^3.1.0",
-            "is-glob": "^3.1.0",
-            "kind-of": "^3.1.0",
-            "lazy-cache": "^2.0.2",
-            "matched": "^0.4.4",
-            "vinyl": "^2.0.1"
-          }
-        },
-        "matched": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
-          "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
-          "requires": {
-            "arr-union": "^3.1.0",
-            "async-array-reduce": "^0.2.0",
-            "extend-shallow": "^2.0.1",
-            "fs-exists-sync": "^0.1.0",
-            "glob": "^7.0.5",
-            "has-glob": "^0.1.1",
-            "is-valid-glob": "^0.3.0",
-            "lazy-cache": "^2.0.1",
-            "resolve-dir": "^0.1.0"
-          },
-          "dependencies": {
-            "has-glob": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
-              "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
-              "requires": {
-                "is-glob": "^2.0.1"
-              }
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            }
-          }
-        },
-        "replace-ext": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
-          "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw=="
-        },
-        "strip-bom-string": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-0.1.2.tgz",
-          "integrity": "sha1-nG5yCjE7qYNliVGEBcz7iKX0G5w="
-        },
-        "vinyl": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-          "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-          "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
-          }
-        }
-      }
-    },
-    "base-cwd": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/base-cwd/-/base-cwd-0.3.4.tgz",
-      "integrity": "sha1-TQCrY1CgRuGtSrnCMm2heUs+TwE=",
-      "requires": {
-        "empty-dir": "^0.2.0",
-        "find-pkg": "^0.1.2",
-        "is-valid-app": "^0.2.0"
-      }
-    },
-    "base-data": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/base-data/-/base-data-0.6.2.tgz",
-      "integrity": "sha512-wH2ViG6CUO2AaeHSEt6fJTyQAk5gl0oY456DoSC5h8mnHrWUbvdctMCuF53CXgBmi0oalZQppKNH0iamG5+uqw==",
-      "requires": {
-        "arr-flatten": "^1.1.0",
-        "cache-base": "^1.0.0",
-        "extend-shallow": "^2.0.1",
-        "get-value": "^2.0.6",
-        "has-glob": "^1.0.0",
-        "has-value": "^1.0.0",
-        "is-registered": "^0.1.5",
-        "is-valid-app": "^0.3.0",
-        "kind-of": "^5.0.0",
-        "lazy-cache": "^2.0.2",
-        "merge-value": "^1.0.0",
-        "mixin-deep": "^1.2.0",
-        "read-file": "^0.2.0",
-        "resolve-glob": "^1.0.0",
-        "set-value": "^2.0.0",
-        "union-value": "^1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "has-glob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
-          "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
-          "requires": {
-            "is-glob": "^3.0.0"
-          }
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        },
-        "is-valid-app": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.3.0.tgz",
-          "integrity": "sha1-eBBrdR88oyOF+0VJK/KUF7WZPIA=",
-          "requires": {
-            "debug": "^2.6.3",
-            "is-registered": "^0.1.5",
-            "is-valid-instance": "^0.3.0",
-            "lazy-cache": "^2.0.2"
-          }
-        },
-        "is-valid-instance": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.3.0.tgz",
-          "integrity": "sha1-9KxzAjxNTYubw7PsPmZjBRbijp4=",
-          "requires": {
-            "isobject": "^3.0.0",
-            "pascalcase": "^0.1.1"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-engines": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/base-engines/-/base-engines-0.2.1.tgz",
-      "integrity": "sha1-aXgAyoq4iKM3iXONv6zLgYoqWns=",
-      "requires": {
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "engine-cache": "^0.19.0",
-        "is-valid-app": "^0.1.2",
-        "lazy-cache": "^2.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "is-valid-app": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
-          "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
-          "requires": {
-            "debug": "^2.2.0",
-            "is-registered": "^0.1.5",
-            "is-valid-instance": "^0.1.0",
-            "lazy-cache": "^2.0.1"
-          }
-        },
-        "is-valid-instance": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
-          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
-          "requires": {
-            "isobject": "^2.1.0",
-            "pascalcase": "^0.1.1"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-env": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/base-env/-/base-env-0.3.1.tgz",
-      "integrity": "sha512-/HxC8QV1m/bWqvjcu4WZl4Um1HRpTAjuY31uiFUEukXsXge4WIvNvGKG/gCs2PrpBFPCybowA406V/ivdPknpQ==",
-      "requires": {
-        "base-namespace": "^0.2.0",
-        "contains-path": "^0.1.0",
-        "debug": "^2.2.0",
-        "extend-shallow": "^2.0.1",
-        "fs-exists-sync": "^0.1.0",
-        "global-modules": "^0.2.2",
-        "is-absolute": "^0.2.5",
-        "is-valid-app": "^0.1.0",
-        "is-valid-instance": "^0.1.0",
-        "kind-of": "^3.0.3",
-        "os-homedir": "^1.0.1",
-        "resolve-file": "^0.3.0"
-      },
-      "dependencies": {
-        "cwd": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
-          "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
-          "requires": {
-            "find-pkg": "^0.1.2",
-            "fs-exists-sync": "^0.1.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "is-valid-app": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
-          "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
-          "requires": {
-            "debug": "^2.2.0",
-            "is-registered": "^0.1.5",
-            "is-valid-instance": "^0.1.0",
-            "lazy-cache": "^2.0.1"
-          }
-        },
-        "is-valid-instance": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
-          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
-          "requires": {
-            "isobject": "^2.1.0",
-            "pascalcase": "^0.1.1"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "resolve-file": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/resolve-file/-/resolve-file-0.3.0.tgz",
-          "integrity": "sha1-EeH7RkVm06fFAMt+lIHo8LAKFO8=",
-          "requires": {
-            "cwd": "^0.10.0",
-            "expand-tilde": "^2.0.2",
-            "extend-shallow": "^2.0.1",
-            "fs-exists-sync": "^0.1.0",
-            "homedir-polyfill": "^1.0.1",
-            "lazy-cache": "^2.0.2",
-            "resolve": "^1.2.0"
-          }
-        }
-      }
-    },
-    "base-generators": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/base-generators/-/base-generators-0.4.6.tgz",
-      "integrity": "sha1-4amTYh5bRCr44MgRMVoyb5h8nqY=",
-      "requires": {
-        "async-each-series": "^1.1.0",
-        "base-compose": "^0.2.1",
-        "base-cwd": "^0.3.1",
-        "base-data": "^0.6.0",
-        "base-env": "^0.3.0",
-        "base-option": "^0.8.4",
-        "base-pkg": "^0.2.4",
-        "base-plugins": "^0.4.13",
-        "base-task": "^0.6.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "global-modules": "^0.2.2",
-        "is-valid-app": "^0.2.0",
-        "is-valid-instance": "^0.2.0",
-        "kind-of": "^3.0.3",
-        "lazy-cache": "^2.0.1",
-        "mixin-deep": "^1.1.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-helpers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/base-helpers/-/base-helpers-0.1.1.tgz",
-      "integrity": "sha1-2k4eKy+ACOzc6T8R79223gYzP7M=",
-      "requires": {
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "is-valid-app": "^0.1.0",
-        "lazy-cache": "^2.0.1",
-        "load-helpers": "^0.2.11"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "is-valid-app": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
-          "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
-          "requires": {
-            "debug": "^2.2.0",
-            "is-registered": "^0.1.5",
-            "is-valid-instance": "^0.1.0",
-            "lazy-cache": "^2.0.1"
-          }
-        },
-        "is-valid-instance": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
-          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
-          "requires": {
-            "isobject": "^2.1.0",
-            "pascalcase": "^0.1.1"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-namespace": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/base-namespace/-/base-namespace-0.2.0.tgz",
-      "integrity": "sha1-RLLLumZ1Y8xE5trrTv5AO7CrPaA=",
-      "requires": {
-        "is-valid-app": "^0.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "is-valid-app": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
-          "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
-          "requires": {
-            "debug": "^2.2.0",
-            "is-registered": "^0.1.5",
-            "is-valid-instance": "^0.1.0",
-            "lazy-cache": "^2.0.1"
-          }
-        },
-        "is-valid-instance": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
-          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
-          "requires": {
-            "isobject": "^2.1.0",
-            "pascalcase": "^0.1.1"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-option": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/base-option/-/base-option-0.8.4.tgz",
-      "integrity": "sha1-EUF/qSRPInpNU3tNKRcjRieH1cc=",
-      "requires": {
-        "define-property": "^0.2.5",
-        "get-value": "^2.0.6",
-        "is-valid-app": "^0.2.0",
-        "isobject": "^2.1.0",
-        "lazy-cache": "^2.0.1",
-        "mixin-deep": "^1.1.3",
-        "option-cache": "^3.4.0",
-        "set-value": "^0.3.3"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
-          "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "isobject": "^2.0.0",
-            "to-object-path": "^0.2.0"
-          }
-        },
-        "to-object-path": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
-          "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "is-arguments": "^1.0.2"
-          }
-        }
-      }
-    },
-    "base-pkg": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/base-pkg/-/base-pkg-0.2.5.tgz",
-      "integrity": "sha512-/POxajlgBhVsknwLXnqnbp//bAMh7SkDgHF+z/uoYnFqk46e05c3MxSEmn5vFCB8g4rHHKxAPLKrU/4Yb3vUdA==",
-      "requires": {
-        "cache-base": "^1.0.0",
-        "debug": "^2.6.8",
-        "define-property": "^1.0.0",
-        "expand-pkg": "^0.1.8",
-        "extend-shallow": "^2.0.1",
-        "is-valid-app": "^0.3.0",
-        "log-utils": "^0.2.1",
-        "pkg-store": "^0.2.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "is-valid-app": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.3.0.tgz",
-          "integrity": "sha1-eBBrdR88oyOF+0VJK/KUF7WZPIA=",
-          "requires": {
-            "debug": "^2.6.3",
-            "is-registered": "^0.1.5",
-            "is-valid-instance": "^0.3.0",
-            "lazy-cache": "^2.0.2"
-          }
-        },
-        "is-valid-instance": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.3.0.tgz",
-          "integrity": "sha1-9KxzAjxNTYubw7PsPmZjBRbijp4=",
-          "requires": {
-            "isobject": "^3.0.0",
-            "pascalcase": "^0.1.1"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-plugins": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/base-plugins/-/base-plugins-0.4.13.tgz",
-      "integrity": "sha1-kd8XjcN/hoQt6ihteeSPuGtarD0=",
-      "requires": {
-        "define-property": "^0.2.5",
-        "is-registered": "^0.1.5",
-        "isobject": "^2.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
-    "base-questions": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/base-questions/-/base-questions-0.7.4.tgz",
-      "integrity": "sha1-9k+EgmHtbIKPSYPXgS9A0wN4IUY=",
-      "requires": {
-        "base-store": "^0.4.4",
-        "clone-deep": "^0.2.4",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "is-valid-app": "^0.2.0",
-        "isobject": "^2.1.0",
-        "lazy-cache": "^2.0.1",
-        "mixin-deep": "^1.1.3",
-        "question-store": "^0.11.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-routes": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/base-routes/-/base-routes-0.2.2.tgz",
-      "integrity": "sha1-CmFNFy1JBF2Mk4dxP4YN88QFNB4=",
-      "requires": {
-        "debug": "^2.2.0",
-        "en-route": "^0.7.5",
-        "is-valid-app": "^0.2.0",
-        "lazy-cache": "^2.0.1",
-        "template-error": "^0.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-runtimes": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/base-runtimes/-/base-runtimes-0.2.0.tgz",
-      "integrity": "sha1-GI4+ZoJMyxWYsyh7TqW5NaG4UEU=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-valid-app": "^0.2.0",
-        "lazy-cache": "^2.0.1",
-        "log-utils": "^0.1.4",
-        "micromatch": "^2.3.10",
-        "time-diff": "^0.3.1"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.1.0.tgz",
-          "integrity": "sha1-M0rDbNPq1wjeXGnhmpjRhkImtD8=",
-          "requires": {
-            "ansi-bgblack": "^0.1.1",
-            "ansi-bgblue": "^0.1.1",
-            "ansi-bgcyan": "^0.1.1",
-            "ansi-bggreen": "^0.1.1",
-            "ansi-bgmagenta": "^0.1.1",
-            "ansi-bgred": "^0.1.1",
-            "ansi-bgwhite": "^0.1.1",
-            "ansi-bgyellow": "^0.1.1",
-            "ansi-black": "^0.1.1",
-            "ansi-blue": "^0.1.1",
-            "ansi-bold": "^0.1.1",
-            "ansi-cyan": "^0.1.1",
-            "ansi-dim": "^0.1.1",
-            "ansi-gray": "^0.1.1",
-            "ansi-green": "^0.1.1",
-            "ansi-grey": "^0.1.1",
-            "ansi-hidden": "^0.1.1",
-            "ansi-inverse": "^0.1.1",
-            "ansi-italic": "^0.1.1",
-            "ansi-magenta": "^0.1.1",
-            "ansi-red": "^0.1.1",
-            "ansi-reset": "^0.1.1",
-            "ansi-strikethrough": "^0.1.1",
-            "ansi-underline": "^0.1.1",
-            "ansi-white": "^0.1.1",
-            "ansi-yellow": "^0.1.1",
-            "lazy-cache": "^0.2.4"
-          },
-          "dependencies": {
-            "lazy-cache": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-            }
-          }
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "log-utils": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.1.5.tgz",
-          "integrity": "sha1-3g84+Vf0zW69Xctoddijua4HT3c=",
-          "requires": {
-            "ansi-colors": "^0.1.0",
-            "error-symbol": "^0.1.0",
-            "info-symbol": "^0.1.0",
-            "log-ok": "^0.1.1",
-            "success-symbol": "^0.1.0",
-            "time-stamp": "^1.0.1",
-            "warning-symbol": "^0.1.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
-      }
-    },
-    "base-store": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/base-store/-/base-store-0.4.4.tgz",
-      "integrity": "sha1-JY32uKYu4G/xUADJSdD9fCi68mY=",
-      "requires": {
-        "data-store": "^0.16.0",
-        "debug": "^2.2.0",
-        "extend-shallow": "^2.0.1",
-        "is-registered": "^0.1.4",
-        "is-valid-instance": "^0.1.0",
-        "lazy-cache": "^2.0.1",
-        "project-name": "^0.2.5"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "is-valid-instance": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
-          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
-          "requires": {
-            "isobject": "^2.1.0",
-            "pascalcase": "^0.1.1"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "base-task": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/base-task/-/base-task-0.6.2.tgz",
-      "integrity": "sha1-Rn1guuBzezuJab/1f6RElJiZgcA=",
-      "requires": {
-        "composer": "^0.13.0",
-        "is-valid-app": "^0.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "is-valid-app": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.1.2.tgz",
-          "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
-          "requires": {
-            "debug": "^2.2.0",
-            "is-registered": "^0.1.5",
-            "is-valid-instance": "^0.1.0",
-            "lazy-cache": "^2.0.1"
-          }
-        },
-        "is-valid-instance": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.1.0.tgz",
-          "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
-          "requires": {
-            "isobject": "^2.1.0",
-            "pascalcase": "^0.1.1"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
           }
         }
       }
@@ -4944,6 +2776,16 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      },
+      "dependencies": {
+        "set-value": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-3.0.2.tgz",
+          "integrity": "sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
       }
     },
     "cache-loader": {
@@ -5193,19 +3035,6 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
       "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
     },
-    "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "requires": {
-        "restore-cursor": "^1.0.1"
-      }
-    },
-    "cli-width": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-      "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0="
-    },
     "clipboard": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
@@ -5232,38 +3061,6 @@
         "wordwrap": "0.0.2"
       }
     },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-    },
-    "clone-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
-    },
-    "clone-deep": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-      "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
-      "requires": {
-        "for-own": "^0.1.3",
-        "is-plain-object": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "lazy-cache": "^1.0.3",
-        "shallow-clone": "^0.1.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -5271,55 +3068,6 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
-    },
-    "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-    },
-    "cloneable-readable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
-      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "coa": {
       "version": "2.0.2",
@@ -5330,11 +3078,6 @@
         "chalk": "^2.4.1",
         "q": "^1.1.2"
       }
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -5394,174 +3137,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
       "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
     },
-    "common-config": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/common-config/-/common-config-0.1.1.tgz",
-      "integrity": "sha512-mDp+nqoFbYsHKZfjg8OSb0CYfdPkuoGTMCVKy4ceYHR0EACTLV/qG8Q4cih2c/0IleQ7SISiqWqLMLXXZnJ2FA==",
-      "requires": {
-        "composer": "^0.13.0",
-        "data-store": "^0.16.1",
-        "get-value": "^2.0.6",
-        "lazy-cache": "^2.0.1",
-        "log-utils": "^0.2.0",
-        "object.pick": "^1.1.2",
-        "omit-empty": "^0.4.1",
-        "question-cache": "^0.4.0",
-        "set-value": "^3.0.1",
-        "strip-color": "^0.1.0",
-        "tableize-object": "^0.1.0",
-        "text-table": "^0.2.0",
-        "yargs-parser": "^2.4.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "question-cache": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/question-cache/-/question-cache-0.4.0.tgz",
-          "integrity": "sha1-4rmTf8X7fcYPu58QXx+iVLM96n0=",
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "arr-union": "^3.1.0",
-            "async": "1.5.2",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "get-value": "^2.0.5",
-            "has-value": "^0.3.1",
-            "inquirer2": "^0.1.1",
-            "is-answer": "^0.1.0",
-            "isobject": "^2.0.0",
-            "lazy-cache": "^1.0.3",
-            "mixin-deep": "^1.1.3",
-            "omit-empty": "^0.3.6",
-            "option-cache": "^3.3.5",
-            "os-homedir": "^1.0.1",
-            "project-name": "^0.2.4",
-            "set-value": "^0.3.3",
-            "to-choices": "^0.2.0",
-            "use": "^1.1.2"
-          },
-          "dependencies": {
-            "lazy-cache": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-            },
-            "omit-empty": {
-              "version": "0.3.6",
-              "resolved": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.3.6.tgz",
-              "integrity": "sha1-bThAXyqmHJEetQT+aIBcVm2FwxY=",
-              "requires": {
-                "has-values": "^0.1.4",
-                "is-date-object": "^1.0.1",
-                "isobject": "^2.0.0",
-                "reduce-object": "^0.1.3"
-              }
-            },
-            "set-value": {
-              "version": "0.3.3",
-              "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
-              "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
-              "requires": {
-                "extend-shallow": "^2.0.1",
-                "isobject": "^2.0.0",
-                "to-object-path": "^0.2.0"
-              }
-            }
-          }
-        },
-        "set-value": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-3.0.2.tgz",
-          "integrity": "sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        },
-        "to-object-path": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
-          "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "is-arguments": "^1.0.2"
-          }
-        },
-        "use": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/use/-/use-1.1.2.tgz",
-          "integrity": "sha1-bjgy/rholXNJSsanrLX++zd7LNE=",
-          "requires": {
-            "define-property": "^0.2.5",
-            "isobject": "^2.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-          "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
-          }
-        }
-      }
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -5571,139 +3146,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-    },
-    "composer": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/composer/-/composer-0.13.0.tgz",
-      "integrity": "sha1-HbyxXxmpBt7uSanD0TfmVLvG0OI=",
-      "requires": {
-        "array-unique": "^0.2.1",
-        "bach": "^0.5.0",
-        "co": "^4.6.0",
-        "component-emitter": "^1.2.1",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "is-generator": "^1.0.3",
-        "is-glob": "^2.0.1",
-        "isobject": "^2.1.0",
-        "lazy-cache": "^2.0.1",
-        "micromatch": "^2.3.8",
-        "nanoseconds": "^0.1.0"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
-      }
     },
     "compressible": {
       "version": "2.0.18",
@@ -5849,11 +3291,6 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
-    "contains-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
-    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -5917,11 +3354,6 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
-    "copy-task": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/copy-task/-/copy-task-0.1.0.tgz",
-      "integrity": "sha1-TDT+muVPKq9gntMvhbj3l6H0arY="
-    },
     "copy-webpack-plugin": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
@@ -5972,6 +3404,14 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "requires": {
+            "randombytes": "^2.1.0"
           }
         },
         "slash": {
@@ -6304,14 +3744,6 @@
         }
       }
     },
-    "cwd": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz",
-      "integrity": "sha1-QeEKfhq4M9xZwuyoOBTH3ne1pP0=",
-      "requires": {
-        "find-pkg": "^0.1.0"
-      }
-    },
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -6323,162 +3755,6 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "data-store": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/data-store/-/data-store-0.16.1.tgz",
-      "integrity": "sha1-5pwDpcrBXR/zPwJUyWeDZT5ogwQ=",
-      "requires": {
-        "cache-base": "^0.8.4",
-        "clone-deep": "^0.2.4",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "graceful-fs": "^4.1.4",
-        "has-own-deep": "^0.1.4",
-        "lazy-cache": "^2.0.1",
-        "mkdirp": "^0.5.1",
-        "project-name": "^0.2.5",
-        "resolve-dir": "^0.1.0",
-        "rimraf": "^2.5.3",
-        "union-value": "^0.2.3"
-      },
-      "dependencies": {
-        "cache-base": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
-          "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
-          "requires": {
-            "collection-visit": "^0.2.1",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.5",
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0",
-            "lazy-cache": "^2.0.1",
-            "set-value": "^0.4.2",
-            "to-object-path": "^0.3.0",
-            "union-value": "^0.2.3",
-            "unset-value": "^0.1.1"
-          }
-        },
-        "collection-visit": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
-          "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
-          "requires": {
-            "lazy-cache": "^2.0.1",
-            "map-visit": "^0.1.5",
-            "object-visit": "^0.3.4"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            }
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "map-visit": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
-          "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
-          "requires": {
-            "lazy-cache": "^2.0.1",
-            "object-visit": "^0.3.4"
-          }
-        },
-        "object-visit": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
-          "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
-          "requires": {
-            "isobject": "^2.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            }
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        },
-        "union-value": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
-          "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
-          "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
-          }
-        },
-        "unset-value": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
-          "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
-          "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
-          }
-        }
       }
     },
     "de-indent": {
@@ -6512,14 +3788,6 @@
         "mimic-response": "^1.0.0"
       }
     },
-    "deep-bind": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/deep-bind/-/deep-bind-0.3.0.tgz",
-      "integrity": "sha1-lcMd2Eoc0bOBEZosQu25DbSFvDM=",
-      "requires": {
-        "mixin-deep": "^1.1.3"
-      }
-    },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -6543,21 +3811,6 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
       "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
     },
-    "default-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
-      "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
-      "requires": {
-        "kind-of": "^5.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -6565,23 +3818,6 @@
       "requires": {
         "execa": "^1.0.0",
         "ip-regex": "^2.1.0"
-      }
-    },
-    "defaults-deep": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/defaults-deep/-/defaults-deep-0.2.4.tgz",
-      "integrity": "sha512-V6BtqzcMvn0EPOy7f+SfMhfmTawq+7UQdt9yZH0EBK89+IHo5f+Hse/qzTorAXOBrQpxpwb6cB/8OgtaMrT+Fg==",
-      "requires": {
-        "for-own": "^0.1.3",
-        "is-extendable": "^0.1.1",
-        "lazy-cache": "^0.2.3"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-        }
       }
     },
     "defer-to-connect": {
@@ -6679,38 +3915,6 @@
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
       "optional": true
-    },
-    "delimiter-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/delimiter-regex/-/delimiter-regex-2.0.0.tgz",
-      "integrity": "sha1-DQ9vYdmRVZH9Qwh6jpWF0+IRWnU=",
-      "requires": {
-        "extend-shallow": "^1.1.2",
-        "isobject": "^2.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-          "requires": {
-            "kind-of": "^1.1.0"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
-        }
-      }
     },
     "depd": {
       "version": "1.1.2",
@@ -6918,11 +4122,6 @@
         "is-obj": "^2.0.0"
       }
     },
-    "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
-    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -7018,58 +4217,6 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
-    "empty-dir": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/empty-dir/-/empty-dir-0.2.1.tgz",
-      "integrity": "sha1-gJ7kih60rRy1EMJXLWb9DthNAas=",
-      "requires": {
-        "fs-exists-sync": "^0.1.0"
-      }
-    },
-    "en-route": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/en-route/-/en-route-0.7.5.tgz",
-      "integrity": "sha1-6CMOc4NsXpXGdX4EQtPBExJL3Zg=",
-      "requires": {
-        "arr-flatten": "^1.0.1",
-        "debug": "^2.2.0",
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "lazy-cache": "^1.0.3",
-        "path-to-regexp": "^1.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
-      }
-    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -7082,170 +4229,6 @@
       "requires": {
         "once": "^1.4.0"
       }
-    },
-    "engine": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/engine/-/engine-0.1.12.tgz",
-      "integrity": "sha1-+H6MkLuAzT9YWXrFaVk+5G2idC0=",
-      "requires": {
-        "assign-deep": "^0.4.3",
-        "collection-visit": "^0.2.0",
-        "get-value": "^1.2.1",
-        "kind-of": "^2.0.1",
-        "lazy-cache": "^0.2.3",
-        "object.omit": "^2.0.0",
-        "set-value": "^0.2.0"
-      },
-      "dependencies": {
-        "collection-visit": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
-          "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
-          "requires": {
-            "lazy-cache": "^2.0.1",
-            "map-visit": "^0.1.5",
-            "object-visit": "^0.3.4"
-          },
-          "dependencies": {
-            "lazy-cache": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-              "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-              "requires": {
-                "set-getter": "^0.1.0"
-              }
-            }
-          }
-        },
-        "get-value": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
-          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "is-extendable": "^0.1.1",
-            "lazy-cache": "^0.2.4",
-            "noncharacters": "^1.1.0"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-          "requires": {
-            "is-buffer": "^1.0.2"
-          }
-        },
-        "lazy-cache": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-        },
-        "map-visit": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
-          "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
-          "requires": {
-            "lazy-cache": "^2.0.1",
-            "object-visit": "^0.3.4"
-          },
-          "dependencies": {
-            "lazy-cache": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-              "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-              "requires": {
-                "set-getter": "^0.1.0"
-              }
-            }
-          }
-        },
-        "object-visit": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
-          "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
-          "requires": {
-            "isobject": "^2.0.0"
-          }
-        },
-        "set-value": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.2.0.tgz",
-          "integrity": "sha1-c7CmglwVjGoWqCu9yVd1vyqCX6s=",
-          "requires": {
-            "isobject": "^1.0.0",
-            "noncharacters": "^1.1.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
-              "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o="
-            }
-          }
-        }
-      }
-    },
-    "engine-base": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/engine-base/-/engine-base-0.1.3.tgz",
-      "integrity": "sha1-1ZycxS591t0rSa579ftEmU9wFqU=",
-      "requires": {
-        "component-emitter": "^1.2.1",
-        "delimiter-regex": "^2.0.0",
-        "engine": "^0.1.12",
-        "engine-utils": "^0.1.1",
-        "lazy-cache": "^2.0.2",
-        "mixin-deep": "^1.1.3",
-        "object.omit": "^2.0.1",
-        "object.pick": "^1.2.0"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "engine-cache": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/engine-cache/-/engine-cache-0.19.4.tgz",
-      "integrity": "sha1-giSWb732pl54Dsed+HtrLLgjlbI=",
-      "requires": {
-        "async-helpers": "^0.3.9",
-        "extend-shallow": "^2.0.1",
-        "helper-cache": "^0.7.2",
-        "isobject": "^3.0.0",
-        "lazy-cache": "^2.0.2",
-        "mixin-deep": "^1.1.3"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "engine-utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/engine-utils/-/engine-utils-0.1.1.tgz",
-      "integrity": "sha1-rd9HCN2FoFoyF6l3l+q4oBPE+A4="
     },
     "enhanced-resolve": {
       "version": "4.3.0",
@@ -7329,11 +4312,6 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "error-symbol": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/error-symbol/-/error-symbol-0.1.0.tgz",
-      "integrity": "sha1-Ck2uN9YA0VopukU9jvkg8YRDM/Y="
     },
     "es-abstract": {
       "version": "1.17.6",
@@ -7481,70 +4459,6 @@
         "strip-eof": "^1.0.0"
       }
     },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
-    },
-    "expand-args": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/expand-args/-/expand-args-0.4.3.tgz",
-      "integrity": "sha1-OoZiJBxYF1fIzTf7d2d6xgL/nZg=",
-      "requires": {
-        "expand-object": "^0.4.2",
-        "kind-of": "^3.0.3",
-        "lazy-cache": "^2.0.1",
-        "minimist": "^1.2.0",
-        "mixin-deep": "^1.1.3",
-        "omit-empty": "^0.4.1",
-        "set-value": "^0.3.3"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
-          "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "isobject": "^2.0.0",
-            "to-object-path": "^0.2.0"
-          }
-        },
-        "to-object-path": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
-          "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "is-arguments": "^1.0.2"
-          }
-        }
-      }
-    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -7575,171 +4489,6 @@
             "is-descriptor": "^0.1.0"
           }
         }
-      }
-    },
-    "expand-object": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/expand-object/-/expand-object-0.4.2.tgz",
-      "integrity": "sha1-t/J+9pwv3MYrD5OQwMtHvAa7Buo=",
-      "requires": {
-        "get-stdin": "^5.0.1",
-        "is-number": "^2.1.0",
-        "minimist": "^1.2.0",
-        "set-value": "^0.3.3"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "set-value": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
-          "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "isobject": "^2.0.0",
-            "to-object-path": "^0.2.0"
-          }
-        },
-        "to-object-path": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
-          "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "is-arguments": "^1.0.2"
-          }
-        }
-      }
-    },
-    "expand-pkg": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/expand-pkg/-/expand-pkg-0.1.9.tgz",
-      "integrity": "sha512-Qqtqzx/e8tODrDr0H8HtO7+nftN0wH9bsk3948KpKBZLrc86Cm3/8mRKJmDfNSDWWcuKsilMmFlKPhYx5gHYuA==",
-      "requires": {
-        "component-emitter": "^1.2.1",
-        "debug": "^2.4.1",
-        "defaults-deep": "^0.2.4",
-        "export-files": "^2.1.1",
-        "get-value": "^2.0.6",
-        "kind-of": "^3.1.0",
-        "lazy-cache": "^2.0.2",
-        "load-pkg": "^3.0.1",
-        "mixin-deep": "^1.1.3",
-        "normalize-pkg": "^0.3.20",
-        "omit-empty": "^0.4.1",
-        "parse-author": "^1.0.0",
-        "parse-git-config": "^1.1.1",
-        "repo-utils": "^0.3.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "requires": {
-        "fill-range": "^2.1.0"
-      },
-      "dependencies": {
-        "fill-range": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-          "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "expand-tilde": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-      "requires": {
-        "homedir-polyfill": "^1.0.1"
-      }
-    },
-    "export-files": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
-      "integrity": "sha1-u/ZFdAU6CeTrmOX0NQHVcrLDzn8=",
-      "requires": {
-        "lazy-cache": "^1.0.3"
       }
     },
     "express": {
@@ -7868,21 +4617,6 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
-    "falsey": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/falsey/-/falsey-0.3.2.tgz",
-      "integrity": "sha512-lxEuefF5MBIVDmE6XeqCdM4BWk1+vYmGZtkbKZ/VFcg6uBBw6fXNEbWmxCjDdQlFc9hy450nkiWwM3VAW6G1qg==",
-      "requires": {
-        "kind-of": "^5.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7927,36 +4661,6 @@
         "escape-string-regexp": "^1.0.5"
       }
     },
-    "file-contents": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/file-contents/-/file-contents-0.2.4.tgz",
-      "integrity": "sha1-BQb3uO/2KvpFrkXaTfnp1H30U8s=",
-      "requires": {
-        "extend-shallow": "^2.0.0",
-        "file-stat": "^0.1.0",
-        "graceful-fs": "^4.1.2",
-        "is-buffer": "^1.1.0",
-        "is-utf8": "^0.2.0",
-        "lazy-cache": "^0.2.3",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-        }
-      }
-    },
-    "file-is-binary": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-is-binary/-/file-is-binary-1.0.0.tgz",
-      "integrity": "sha1-XkGAbRvK5FjI/sMv484SLbu8Q1Y=",
-      "requires": {
-        "is-binary-buffer": "^1.0.0",
-        "isobject": "^3.0.0"
-      }
-    },
     "file-loader": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
@@ -7978,38 +4682,11 @@
         }
       }
     },
-    "file-name": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz",
-      "integrity": "sha1-ErEi8SD5w028F2wauBpUis7W3vc="
-    },
-    "file-stat": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/file-stat/-/file-stat-0.1.3.tgz",
-      "integrity": "sha1-0PGWHX0QcykoEgpuaVVHHCpbVBE=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "lazy-cache": "^0.2.3",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-        }
-      }
-    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "optional": true
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -8056,23 +4733,6 @@
         "pkg-dir": "^3.0.0"
       }
     },
-    "find-file-up": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
-      "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
-      "requires": {
-        "fs-exists-sync": "^0.1.0",
-        "resolve-dir": "^0.1.0"
-      }
-    },
-    "find-pkg": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
-      "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
-      "requires": {
-        "find-file-up": "^0.1.2"
-      }
-    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -8080,11 +4740,6 @@
       "requires": {
         "locate-path": "^3.0.0"
       }
-    },
-    "first-chunk-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -8136,14 +4791,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "requires": {
-        "for-in": "^1.0.1"
-      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -8220,11 +4867,6 @@
           }
         }
       }
-    },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
     },
     "fs-extra": {
       "version": "7.0.1",
@@ -8311,11 +4953,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
-    "get-stdin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
-    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -8329,42 +4966,12 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
-    "get-view": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/get-view/-/get-view-0.1.3.tgz",
-      "integrity": "sha1-NmCsBYuhPfl0nKvKpry5bUGqDqA=",
-      "requires": {
-        "isobject": "^3.0.0",
-        "match-file": "^0.2.1"
-      }
-    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "git-config-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-      "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "fs-exists-sync": "^0.1.0",
-        "homedir-polyfill": "^1.0.0"
-      }
-    },
-    "git-repo-name": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
-      "integrity": "sha1-rwmIRlaqU37GJccIcAgXXNYSKP8=",
-      "requires": {
-        "cwd": "^0.9.1",
-        "file-name": "^0.1.0",
-        "lazy-cache": "^1.0.4",
-        "remote-origin-url": "^0.5.1"
       }
     },
     "glob": {
@@ -8378,38 +4985,6 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
       }
     },
     "glob-parent": {
@@ -8427,153 +5002,6 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
             "is-extglob": "^2.1.0"
-          }
-        }
-      }
-    },
-    "glob-stream": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-      "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-      "requires": {
-        "extend": "^3.0.0",
-        "glob": "^5.0.3",
-        "glob-parent": "^3.0.0",
-        "micromatch": "^2.3.7",
-        "ordered-read-streams": "^0.3.0",
-        "through2": "^0.6.0",
-        "to-absolute-glob": "^0.1.1",
-        "unique-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -8598,45 +5026,6 @@
       "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
       "requires": {
         "ini": "^1.3.5"
-      }
-    },
-    "global-modules": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "requires": {
-        "global-prefix": "^0.1.4",
-        "is-windows": "^0.2.0"
-      },
-      "dependencies": {
-        "global-prefix": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-          "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-          "requires": {
-            "homedir-polyfill": "^1.0.0",
-            "ini": "^1.3.4",
-            "is-windows": "^0.2.0",
-            "which": "^1.2.12"
-          }
-        },
-        "is-windows": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
-        }
-      }
-    },
-    "global-prefix": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-      "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -8702,59 +5091,6 @@
         "strip-bom-string": "^1.0.0"
       }
     },
-    "group-array": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/group-array/-/group-array-0.3.4.tgz",
-      "integrity": "sha512-YAmNsgsi1uQ7Ai3T4FFkMoskqbLEUPRajAmrn8FclwZQQnV98NLrNWjQ3n2+i1pANxdO3n6wsNEkKq5XrYy0Ow==",
-      "requires": {
-        "arr-flatten": "^1.0.1",
-        "for-own": "^0.1.4",
-        "get-value": "^2.0.6",
-        "kind-of": "^3.1.0",
-        "split-string": "^1.0.1",
-        "union-value": "^1.0.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "split-string": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/split-string/-/split-string-1.0.1.tgz",
-          "integrity": "sha1-vLqz9BUqzuOg1qskecDSh5w9s84=",
-          "requires": {
-            "extend-shallow": "^2.0.1"
-          }
-        }
-      }
-    },
-    "gulp-choose-files": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/gulp-choose-files/-/gulp-choose-files-0.1.3.tgz",
-      "integrity": "sha1-hrFfBjAHOrZz1XJb7sY+qhSFUPk=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "question-cache": "^0.5.1",
-        "through2": "^2.0.1"
-      }
-    },
-    "gulp-sourcemaps": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-      "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-      "requires": {
-        "convert-source-map": "^1.1.1",
-        "graceful-fs": "^4.1.2",
-        "strip-bom": "^2.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0"
-      }
-    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -8794,34 +5130,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "has-glob": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
-      "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
-      "requires": {
-        "is-glob": "^2.0.1"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
-    "has-own-deep": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/has-own-deep/-/has-own-deep-0.1.4.tgz",
-      "integrity": "sha1-kesM2ieAgxWPgEKigxZDTpr+eHY="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -8891,23 +5199,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
-    "helper-cache": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/helper-cache/-/helper-cache-0.7.2.tgz",
-      "integrity": "sha1-AkVixLS4sqsqtTHQC+FuxJZRi5A=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "lazy-cache": "^0.2.3",
-        "lodash.bind": "^3.1.0"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-        }
-      }
-    },
     "hex-color-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
@@ -8937,14 +5228,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
           "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
         }
-      }
-    },
-    "homedir-polyfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-      "requires": {
-        "parse-passwd": "^1.0.0"
       }
     },
     "hotkeys-js": {
@@ -9229,11 +5512,6 @@
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
     },
-    "inflection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
-      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -9242,11 +5520,6 @@
         "once": "^1.3.0",
         "wrappy": "1"
       }
-    },
-    "info-symbol": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/info-symbol/-/info-symbol-0.1.0.tgz",
-      "integrity": "sha1-J4QdcoZ920JCzWEtecEGM4gcang="
     },
     "inherits": {
       "version": "2.0.4",
@@ -9257,91 +5530,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-    },
-    "inquirer2": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/inquirer2/-/inquirer2-0.1.1.tgz",
-      "integrity": "sha1-vFQkqBQ1fEHmXi6Vf+U2ruqb8fY=",
-      "requires": {
-        "ansi-escapes": "^1.1.1",
-        "ansi-regex": "^2.0.0",
-        "arr-flatten": "^1.0.1",
-        "arr-pluck": "^0.1.0",
-        "array-unique": "^0.2.1",
-        "chalk": "^1.1.1",
-        "cli-cursor": "^1.0.2",
-        "cli-width": "^1.1.0",
-        "extend-shallow": "^2.0.1",
-        "figures": "^1.4.0",
-        "is-number": "^2.1.0",
-        "is-plain-object": "^2.0.1",
-        "lazy-cache": "^1.0.3",
-        "lodash.where": "^3.1.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^4.0.7",
-        "strip-color": "^0.1.0",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
     },
     "internal-ip": {
       "version": "4.3.0",
@@ -9375,22 +5563,6 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
-    "is-absolute": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
-      "requires": {
-        "is-relative": "^0.2.1",
-        "is-windows": "^0.2.0"
-      },
-      "dependencies": {
-        "is-windows": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
-        }
-      }
-    },
     "is-absolute-url": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
@@ -9414,23 +5586,6 @@
         }
       }
     },
-    "is-answer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-answer/-/is-answer-0.1.1.tgz",
-      "integrity": "sha1-zBwvGG+FzyZQIgveNZ2GIYfUnLY=",
-      "requires": {
-        "has-values": "^0.1.4",
-        "is-primitive": "^2.0.0",
-        "omit-empty": "^0.4.1"
-      },
-      "dependencies": {
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        }
-      }
-    },
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
@@ -9440,14 +5595,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-    },
-    "is-binary-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-binary-buffer/-/is-binary-buffer-1.0.0.tgz",
-      "integrity": "sha1-vGAxKQtly/eZudlQK1D9U3VSQAc=",
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -9540,19 +5687,6 @@
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
     },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "requires": {
-        "is-primitive": "^2.0.0"
-      }
-    },
     "is-expression": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
@@ -9583,11 +5717,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-    },
-    "is-generator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
-      "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -9675,16 +5804,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-    },
     "is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -9696,41 +5815,6 @@
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "requires": {
         "has": "^1.0.3"
-      }
-    },
-    "is-registered": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/is-registered/-/is-registered-0.1.5.tgz",
-      "integrity": "sha1-HTRpd0GdZl4qxshAE1NWheb3b38=",
-      "requires": {
-        "define-property": "^0.2.5",
-        "isobject": "^2.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
-    "is-relative": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-      "requires": {
-        "is-unc-path": "^0.1.1"
       }
     },
     "is-resolvable": {
@@ -9763,77 +5847,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "is-unc-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-      "requires": {
-        "unc-path-regex": "^0.1.0"
-      }
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-    },
-    "is-valid-app": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-valid-app/-/is-valid-app-0.2.1.tgz",
-      "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
-      "requires": {
-        "debug": "^2.2.0",
-        "is-registered": "^0.1.5",
-        "is-valid-instance": "^0.2.0",
-        "lazy-cache": "^2.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "is-valid-glob": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-      "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
-    },
-    "is-valid-instance": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/is-valid-instance/-/is-valid-instance-0.2.0.tgz",
-      "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
-      "requires": {
-        "isobject": "^2.1.0",
-        "pascalcase": "^0.1.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
-    "is-whitespace": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
-      "integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -9928,11 +5941,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -10033,81 +6041,10 @@
         "package-json": "^6.3.0"
       }
     },
-    "layouts": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/layouts/-/layouts-0.11.0.tgz",
-      "integrity": "sha1-xiDos8uI/IxJLbRTin3VQKTffyI=",
-      "requires": {
-        "delimiter-regex": "^1.3.1",
-        "falsey": "^0.3.0",
-        "get-view": "^0.1.1",
-        "lazy-cache": "^1.0.3"
-      },
-      "dependencies": {
-        "delimiter-regex": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/delimiter-regex/-/delimiter-regex-1.3.1.tgz",
-          "integrity": "sha1-Y4XK4UAE28DBzY3//+uGPVGZnv8=",
-          "requires": {
-            "extend-shallow": "^1.1.2"
-          }
-        },
-        "extend-shallow": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-          "requires": {
-            "kind-of": "^1.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
-        }
-      }
-    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-    },
-    "lazystream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-      "requires": {
-        "readable-stream": "^2.0.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
     },
     "leven": {
       "version": "3.1.0",
@@ -10130,126 +6067,10 @@
         "uc.micro": "^1.0.1"
       }
     },
-    "load-helpers": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/load-helpers/-/load-helpers-0.2.11.tgz",
-      "integrity": "sha1-9L2LIYQ1wFLl4536dxMinVcepCM=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-valid-glob": "^0.3.0",
-        "lazy-cache": "^2.0.1",
-        "matched": "^0.4.1",
-        "resolve-dir": "^0.1.0"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "matched": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
-          "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
-          "requires": {
-            "arr-union": "^3.1.0",
-            "async-array-reduce": "^0.2.0",
-            "extend-shallow": "^2.0.1",
-            "fs-exists-sync": "^0.1.0",
-            "glob": "^7.0.5",
-            "has-glob": "^0.1.1",
-            "is-valid-glob": "^0.3.0",
-            "lazy-cache": "^2.0.1",
-            "resolve-dir": "^0.1.0"
-          }
-        }
-      }
-    },
-    "load-pkg": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/load-pkg/-/load-pkg-3.0.1.tgz",
-      "integrity": "sha1-kjCzfsBOVpADBgvFiVHj7VCNWU8=",
-      "requires": {
-        "find-pkg": "^0.1.0"
-      }
-    },
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
       "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
-    },
-    "load-templates": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/load-templates/-/load-templates-0.11.4.tgz",
-      "integrity": "sha1-zyk977a1hg/1uMRJ2qHAx7tyjek=",
-      "requires": {
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "glob-parent": "^2.0.0",
-        "has-glob": "^0.1.1",
-        "is-valid-glob": "^0.3.0",
-        "lazy-cache": "^2.0.1",
-        "matched": "^0.4.1",
-        "to-file": "^0.2.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "matched": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
-          "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
-          "requires": {
-            "arr-union": "^3.1.0",
-            "async-array-reduce": "^0.2.0",
-            "extend-shallow": "^2.0.1",
-            "fs-exists-sync": "^0.1.0",
-            "glob": "^7.0.5",
-            "has-glob": "^0.1.1",
-            "is-valid-glob": "^0.3.0",
-            "lazy-cache": "^2.0.1",
-            "resolve-dir": "^0.1.0"
-          }
-        }
-      }
     },
     "loader-runner": {
       "version": "2.4.0",
@@ -10280,112 +6101,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
-    "lodash._arrayfilter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arrayfilter/-/lodash._arrayfilter-3.0.0.tgz",
-      "integrity": "sha1-LevhHuxp5dzG9LhhNxKKSPFSQjc="
-    },
-    "lodash._basecallback": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
-      "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
-      "requires": {
-        "lodash._baseisequal": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.pairs": "^3.0.0"
-      }
-    },
-    "lodash._baseeach": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
-      "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
-      "requires": {
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._basefilter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basefilter/-/lodash._basefilter-3.0.0.tgz",
-      "integrity": "sha1-S3ZAPfDihtA9Xg9yle00QeEB0SE=",
-      "requires": {
-        "lodash._baseeach": "^3.0.0"
-      }
-    },
-    "lodash._baseisequal": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
-      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
-      "requires": {
-        "lodash.isarray": "^3.0.0",
-        "lodash.istypedarray": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._baseismatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lodash._baseismatch/-/lodash._baseismatch-3.1.3.tgz",
-      "integrity": "sha1-Byj8SO+hFpnT1fLXMEnyqxPED9U=",
-      "requires": {
-        "lodash._baseisequal": "^3.0.0"
-      }
-    },
-    "lodash._basematches": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._basematches/-/lodash._basematches-3.2.0.tgz",
-      "integrity": "sha1-9H4D8H7CB4SrCWjQy2y1l+IQEVg=",
-      "requires": {
-        "lodash._baseismatch": "^3.0.0",
-        "lodash.pairs": "^3.0.0"
-      }
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-    },
-    "lodash._createwrapper": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.2.0.tgz",
-      "integrity": "sha1-30U+ZkFjIXuJWkVAZa8cR6DqPE0=",
-      "requires": {
-        "lodash._root": "^3.0.0"
-      }
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
-    "lodash._replaceholders": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz",
-      "integrity": "sha1-iru3EmxDH37XRPe6rznwi8m9nVg="
-    },
-    "lodash._root": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
-    "lodash.bind": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
-      "integrity": "sha1-+V9IY419i7tYVPkIJmUnmZ+/pLs=",
-      "requires": {
-        "lodash._createwrapper": "^3.0.0",
-        "lodash._replaceholders": "^3.0.0",
-        "lodash.restparam": "^3.0.0"
-      }
     },
     "lodash.chunk": {
       "version": "4.2.0",
@@ -10402,70 +6121,10 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "lodash.filter": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-    },
-    "lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
-    },
-    "lodash.initial": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.initial/-/lodash.initial-4.1.1.tgz",
-      "integrity": "sha1-5T9kiRJl3cQE6YbSwo93vtlDWRo="
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
-    "lodash.istypedarray": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
-      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
-    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
-    },
-    "lodash.last": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
-      "integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
-    },
-    "lodash.map": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -10476,19 +6135,6 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
-    },
-    "lodash.pairs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
-      "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
-      "requires": {
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -10516,85 +6162,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-    },
-    "lodash.where": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.where/-/lodash.where-3.1.0.tgz",
-      "integrity": "sha1-LnhLnJM2jV11qu4zLOF2Ai8rlVM=",
-      "requires": {
-        "lodash._arrayfilter": "^3.0.0",
-        "lodash._basecallback": "^3.0.0",
-        "lodash._basefilter": "^3.0.0",
-        "lodash._basematches": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
-    },
-    "log-ok": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
-      "integrity": "sha1-vqPdNqzQuKckDXhza1uXxlREozQ=",
-      "requires": {
-        "ansi-green": "^0.1.1",
-        "success-symbol": "^0.1.0"
-      }
-    },
-    "log-utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
-      "integrity": "sha1-pMIXoN2aUFFdm5ICBgkas9TgMc8=",
-      "requires": {
-        "ansi-colors": "^0.2.0",
-        "error-symbol": "^0.1.0",
-        "info-symbol": "^0.1.0",
-        "log-ok": "^0.1.1",
-        "success-symbol": "^0.1.0",
-        "time-stamp": "^1.0.1",
-        "warning-symbol": "^0.1.0"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
-          "integrity": "sha1-csMd4qDZoszQysMMyYI+6y9kNLU=",
-          "requires": {
-            "ansi-bgblack": "^0.1.1",
-            "ansi-bgblue": "^0.1.1",
-            "ansi-bgcyan": "^0.1.1",
-            "ansi-bggreen": "^0.1.1",
-            "ansi-bgmagenta": "^0.1.1",
-            "ansi-bgred": "^0.1.1",
-            "ansi-bgwhite": "^0.1.1",
-            "ansi-bgyellow": "^0.1.1",
-            "ansi-black": "^0.1.1",
-            "ansi-blue": "^0.1.1",
-            "ansi-bold": "^0.1.1",
-            "ansi-cyan": "^0.1.1",
-            "ansi-dim": "^0.1.1",
-            "ansi-gray": "^0.1.1",
-            "ansi-green": "^0.1.1",
-            "ansi-grey": "^0.1.1",
-            "ansi-hidden": "^0.1.1",
-            "ansi-inverse": "^0.1.1",
-            "ansi-italic": "^0.1.1",
-            "ansi-magenta": "^0.1.1",
-            "ansi-red": "^0.1.1",
-            "ansi-reset": "^0.1.1",
-            "ansi-strikethrough": "^0.1.1",
-            "ansi-underline": "^0.1.1",
-            "ansi-white": "^0.1.1",
-            "ansi-yellow": "^0.1.1",
-            "lazy-cache": "^2.0.1"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
     },
     "loglevel": {
       "version": "1.6.8",
@@ -10648,157 +6215,10 @@
         }
       }
     },
-    "make-iterator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
-      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
-    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-    },
-    "map-config": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/map-config/-/map-config-0.5.0.tgz",
-      "integrity": "sha1-FwJgfiZ696NwyKnQxiumUk/rb+U=",
-      "requires": {
-        "array-unique": "^0.2.1",
-        "async": "^1.5.2"
-      },
-      "dependencies": {
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        }
-      }
-    },
-    "map-schema": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/map-schema/-/map-schema-0.2.4.tgz",
-      "integrity": "sha1-wZVRg0/DwHoEWXt6WvtEpHWvlbQ=",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "collection-visit": "^0.2.3",
-        "component-emitter": "^1.2.1",
-        "debug": "^2.6.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "get-value": "^2.0.6",
-        "is-primitive": "^2.0.0",
-        "kind-of": "^3.1.0",
-        "lazy-cache": "^2.0.2",
-        "log-utils": "^0.2.1",
-        "longest": "^1.0.1",
-        "mixin-deep": "^1.1.3",
-        "object.omit": "^2.0.1",
-        "object.pick": "^1.2.0",
-        "omit-empty": "^0.4.1",
-        "pad-right": "^0.2.2",
-        "set-value": "^0.4.0",
-        "sort-object-arrays": "^0.1.1",
-        "union-value": "^0.2.3"
-      },
-      "dependencies": {
-        "collection-visit": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
-          "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
-          "requires": {
-            "lazy-cache": "^2.0.1",
-            "map-visit": "^0.1.5",
-            "object-visit": "^0.3.4"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "map-visit": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
-          "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
-          "requires": {
-            "lazy-cache": "^2.0.1",
-            "object-visit": "^0.3.4"
-          }
-        },
-        "object-visit": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
-          "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
-          "requires": {
-            "isobject": "^2.0.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        },
-        "union-value": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
-          "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
-          "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
-          }
-        }
-      }
     },
     "map-visit": {
       "version": "1.0.0",
@@ -10864,183 +6284,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz",
       "integrity": "sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw=="
     },
-    "match-file": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/match-file/-/match-file-0.2.2.tgz",
-      "integrity": "sha1-Jua88bOQpmH2Em+visUB4z7M+uk=",
-      "requires": {
-        "is-glob": "^3.1.0",
-        "isobject": "^3.0.0",
-        "micromatch": "^2.3.11"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          },
-          "dependencies": {
-            "is-extglob": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-            }
-          }
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          },
-          "dependencies": {
-            "is-extglob": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            }
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
-      }
-    },
-    "matched": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/matched/-/matched-1.0.2.tgz",
-      "integrity": "sha512-7ivM1jFZVTOOS77QsR+TtYHH0ecdLclMkqbf5qiJdX2RorqfhsL65QHySPZgDE0ZjHoh+mQUNHTanNXIlzXd0Q==",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "async-array-reduce": "^0.2.1",
-        "glob": "^7.1.2",
-        "has-glob": "^1.0.0",
-        "is-valid-glob": "^1.0.0",
-        "resolve-dir": "^1.0.0"
-      },
-      "dependencies": {
-        "global-modules": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-          "requires": {
-            "global-prefix": "^1.0.1",
-            "is-windows": "^1.0.1",
-            "resolve-dir": "^1.0.0"
-          }
-        },
-        "has-glob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
-          "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
-          "requires": {
-            "is-glob": "^3.0.0"
-          }
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        },
-        "is-valid-glob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-          "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
-        },
-        "resolve-dir": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-          "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-          "requires": {
-            "expand-tilde": "^2.0.0",
-            "global-modules": "^1.0.0"
-          }
-        }
-      }
-    },
-    "math-random": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -11104,26 +6347,6 @@
         }
       }
     },
-    "merge-deep": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
-      "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "clone-deep": "^0.2.4",
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -11135,64 +6358,6 @@
       "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
       "requires": {
         "source-map": "^0.6.1"
-      }
-    },
-    "merge-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-      "requires": {
-        "readable-stream": "^2.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "merge-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/merge-value/-/merge-value-1.0.0.tgz",
-      "integrity": "sha512-fJMmvat4NeKz63Uv9iHWcPDjCWcCkoiRoajRTEO8hlhUC6rwaHg0QCF9hBOTjZmm4JuglPckPSTtcuJL5kp0TQ==",
-      "requires": {
-        "get-value": "^2.0.6",
-        "is-extendable": "^1.0.0",
-        "mixin-deep": "^1.2.0",
-        "set-value": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
       }
     },
     "merge2": {
@@ -11373,22 +6538,6 @@
         }
       }
     },
-    "mixin-object": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-      "requires": {
-        "for-in": "^0.1.3",
-        "is-extendable": "^0.1.1"
-      },
-      "dependencies": {
-        "for-in": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
-        }
-      }
-    },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -11428,11 +6577,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
-    },
-    "mute-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
     },
     "nan": {
       "version": "2.14.1",
@@ -11477,11 +6621,6 @@
         }
       }
     },
-    "nanoseconds": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/nanoseconds/-/nanoseconds-0.1.0.tgz",
-      "integrity": "sha1-aew5/NAOd6s6ct4KQzQoJM15Izo="
-    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -11491,11 +6630,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
-    },
-    "next-tick": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
-      "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -11586,11 +6720,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
       "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA=="
     },
-    "noncharacters": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/noncharacters/-/noncharacters-1.1.0.tgz",
-      "integrity": "sha1-rzPfMP1Q7TxTzSAiWPJa2pC1QNI="
-    },
     "nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
@@ -11603,54 +6732,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-    },
-    "normalize-pkg": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/normalize-pkg/-/normalize-pkg-0.3.20.tgz",
-      "integrity": "sha1-Luc3FJUXhQ2c7/WmI0r174nFFag=",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "array-unique": "^0.3.2",
-        "component-emitter": "^1.2.1",
-        "export-files": "^2.1.1",
-        "extend-shallow": "^2.0.1",
-        "fs-exists-sync": "^0.1.0",
-        "get-value": "^2.0.6",
-        "kind-of": "^3.0.4",
-        "lazy-cache": "^2.0.1",
-        "map-schema": "^0.2.3",
-        "minimist": "^1.2.0",
-        "mixin-deep": "^1.1.3",
-        "omit-empty": "^0.4.1",
-        "parse-git-config": "^1.0.2",
-        "repo-utils": "^0.3.6",
-        "semver": "^5.3.0",
-        "stringify-author": "^0.1.3",
-        "write-json": "^0.2.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -11665,14 +6746,6 @@
         "prepend-http": "^2.0.0",
         "query-string": "^5.0.1",
         "sort-keys": "^2.0.0"
-      }
-    },
-    "now-and-later": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-0.0.6.tgz",
-      "integrity": "sha1-GKFNw/xJXcBs++Ao8AvhbdrE+uo=",
-      "requires": {
-        "once": "^1.3.0"
       }
     },
     "npm-run-path": {
@@ -11700,11 +6773,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -11791,15 +6859,6 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
-      }
-    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -11824,31 +6883,6 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
-    "omit-empty": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
-      "integrity": "sha1-KUo3gvLLIMdJfEEitiN8ncwMY6s=",
-      "requires": {
-        "has-values": "^0.1.4",
-        "kind-of": "^3.0.3",
-        "reduce-object": "^0.1.3"
-      },
-      "dependencies": {
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -11869,11 +6903,6 @@
       "requires": {
         "wrappy": "1"
       }
-    },
-    "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "opencollective-postinstall": {
       "version": "2.0.3",
@@ -11897,112 +6926,6 @@
         "last-call-webpack-plugin": "^3.0.0"
       }
     },
-    "option-cache": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/option-cache/-/option-cache-3.5.0.tgz",
-      "integrity": "sha1-y3ZRVboqhhwRCf8m4qIOqgZhKys=",
-      "requires": {
-        "arr-flatten": "^1.0.3",
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^0.3.1",
-        "kind-of": "^3.2.2",
-        "lazy-cache": "^2.0.2",
-        "set-value": "^0.4.3",
-        "to-object-path": "^0.3.0"
-      },
-      "dependencies": {
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
-      }
-    },
-    "ordered-read-streams": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-      "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-      "requires": {
-        "is-stream": "^1.0.1",
-        "readable-stream": "^2.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "original": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -12015,11 +6938,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -12075,19 +6993,6 @@
         "registry-url": "^5.0.0",
         "semver": "^6.2.0"
       }
-    },
-    "pad-right": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
-      "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
-      "requires": {
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "paginationator": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/paginationator/-/paginationator-0.1.4.tgz",
-      "integrity": "sha1-hHht04UKrh8Ru7kRsMHghRtTgQY="
     },
     "pako": {
       "version": "1.0.11",
@@ -12154,53 +7059,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-author": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-1.0.0.tgz",
-      "integrity": "sha1-XsFZAGKXe9nLOWLpFzuHWGQ39d8="
-    },
-    "parse-git-config": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
-      "integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "fs-exists-sync": "^0.1.0",
-        "git-config-path": "^1.0.1",
-        "ini": "^1.3.4"
-      }
-    },
-    "parse-github-url": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-0.3.2.tgz",
-      "integrity": "sha1-du8B6/4LHpwPSTZylSzGpM2csmA="
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -12210,57 +7068,12 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
-    "parse-passwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
-    },
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "parser-front-matter": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/parser-front-matter/-/parser-front-matter-1.6.4.tgz",
-      "integrity": "sha512-eqtUnI5+COkf1CQOYo8FmykN5Zs+5Yr60f/7GcPgQDZEEjdE/VZ4WMaMo9g37foof8h64t/TH2Uvk2Sq0fDy/g==",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "file-is-binary": "^1.0.0",
-        "gray-matter": "^3.0.2",
-        "isobject": "^3.0.1",
-        "lazy-cache": "^2.0.2",
-        "mixin-deep": "^1.2.0",
-        "trim-leading-lines": "^0.1.1"
-      },
-      "dependencies": {
-        "gray-matter": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.1.1.tgz",
-          "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "js-yaml": "^3.10.0",
-            "kind-of": "^5.0.2",
-            "strip-bom-string": "^1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
       }
     },
     "parseurl": {
@@ -12375,168 +7188,6 @@
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "requires": {
         "find-up": "^3.0.0"
-      }
-    },
-    "pkg-store": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/pkg-store/-/pkg-store-0.2.2.tgz",
-      "integrity": "sha1-sfXA+GIKWf1mWGrMXiVvTCw3oNg=",
-      "requires": {
-        "cache-base": "^0.8.2",
-        "kind-of": "^3.0.2",
-        "lazy-cache": "^1.0.3",
-        "union-value": "^0.2.3",
-        "write-json": "^0.2.2"
-      },
-      "dependencies": {
-        "cache-base": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
-          "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
-          "requires": {
-            "collection-visit": "^0.2.1",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.5",
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0",
-            "lazy-cache": "^2.0.1",
-            "set-value": "^0.4.2",
-            "to-object-path": "^0.3.0",
-            "union-value": "^0.2.3",
-            "unset-value": "^0.1.1"
-          },
-          "dependencies": {
-            "lazy-cache": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-              "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-              "requires": {
-                "set-getter": "^0.1.0"
-              }
-            }
-          }
-        },
-        "collection-visit": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
-          "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
-          "requires": {
-            "lazy-cache": "^2.0.1",
-            "map-visit": "^0.1.5",
-            "object-visit": "^0.3.4"
-          },
-          "dependencies": {
-            "lazy-cache": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-              "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-              "requires": {
-                "set-getter": "^0.1.0"
-              }
-            }
-          }
-        },
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            }
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "map-visit": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
-          "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
-          "requires": {
-            "lazy-cache": "^2.0.1",
-            "object-visit": "^0.3.4"
-          },
-          "dependencies": {
-            "lazy-cache": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-              "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-              "requires": {
-                "set-getter": "^0.1.0"
-              }
-            }
-          }
-        },
-        "object-visit": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
-          "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
-          "requires": {
-            "isobject": "^2.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            }
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        },
-        "union-value": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
-          "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
-          "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
-          }
-        },
-        "unset-value": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
-          "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
-          "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
-          }
-        }
       }
     },
     "portfinder": {
@@ -13114,11 +7765,6 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-    },
     "prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
@@ -13156,16 +7802,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "project-name": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
-      "integrity": "sha1-Pk94H+HulLB4apuuU1BjdsN5r2k=",
-      "requires": {
-        "find-pkg": "^0.1.2",
-        "git-repo-name": "^0.6.0",
-        "minimist": "^1.2.0"
-      }
     },
     "promise": {
       "version": "7.3.1",
@@ -13424,166 +8060,6 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
-    "question-cache": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/question-cache/-/question-cache-0.5.1.tgz",
-      "integrity": "sha1-C8JzKRdTQXB99azTHvLd9nApFo0=",
-      "requires": {
-        "arr-flatten": "^1.0.1",
-        "arr-union": "^3.1.0",
-        "async-each-series": "^1.1.0",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "get-value": "^2.0.6",
-        "has-value": "^0.3.1",
-        "inquirer2": "^0.1.1",
-        "is-answer": "^0.1.0",
-        "isobject": "^2.1.0",
-        "lazy-cache": "^2.0.1",
-        "mixin-deep": "^1.1.3",
-        "omit-empty": "^0.4.1",
-        "option-cache": "^3.4.0",
-        "os-homedir": "^1.0.1",
-        "project-name": "^0.2.5",
-        "set-value": "^0.3.3",
-        "to-choices": "^0.2.0",
-        "use": "^2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
-          "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "isobject": "^2.0.0",
-            "to-object-path": "^0.2.0"
-          }
-        },
-        "to-object-path": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
-          "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "is-arguments": "^1.0.2"
-          }
-        },
-        "use": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
-          "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
-          "requires": {
-            "define-property": "^0.2.5",
-            "isobject": "^3.0.0",
-            "lazy-cache": "^2.0.2"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-            }
-          }
-        }
-      }
-    },
-    "question-store": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/question-store/-/question-store-0.11.1.tgz",
-      "integrity": "sha1-gf1NRF9NWtwqYiPCUj+nEj4E/X0=",
-      "requires": {
-        "common-config": "^0.1.0",
-        "data-store": "^0.16.1",
-        "debug": "^2.2.0",
-        "is-answer": "^0.1.0",
-        "lazy-cache": "^2.0.1",
-        "project-name": "^0.2.6",
-        "question-cache": "^0.5.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
-    "randomatic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-      "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-        }
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13635,11 +8111,6 @@
         "strip-json-comments": "~2.0.1"
       }
     },
-    "read-file": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/read-file/-/read-file-0.2.0.tgz",
-      "integrity": "sha1-cMa6+IQux9FUD5gf0Oau1Mgb1UU="
-    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -13689,40 +8160,12 @@
         }
       }
     },
-    "readline2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "mute-stream": "0.0.5"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        }
-      }
-    },
     "reduce": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/reduce/-/reduce-1.0.2.tgz",
       "integrity": "sha512-xX7Fxke/oHO5IfZSk77lvPa/7bjMh9BuCk4OOoX5XTXrM7s0Z+MkPfSDfz0q7r91BhhGSs8gii/VEN/7zhCPpQ==",
       "requires": {
         "object-keys": "^1.1.0"
-      }
-    },
-    "reduce-object": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz",
-      "integrity": "sha1-1UnUCmwpNvpOPpt4yonJMxRZQhg=",
-      "requires": {
-        "for-own": "^0.1.1"
       }
     },
     "regenerate": {
@@ -13749,14 +8192,6 @@
       "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
       "requires": {
         "@babel/runtime": "^7.8.4"
-      }
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "requires": {
-        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -13850,32 +8285,6 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
-    "relative": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
-      "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
-      "requires": {
-        "isobject": "^2.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
-    "remote-origin-url": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.3.tgz",
-      "integrity": "sha512-crQ7Xk1m/F2IiwBx5oTqk/c0hjoumrEz+a36+ZoVupskQRE/q7pAwHKsTNeiZ31sbSTELvVlVv4h1W0Xo5szKg==",
-      "requires": {
-        "parse-git-config": "^1.1.1"
-      }
-    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -13902,48 +8311,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-    },
-    "repo-utils": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/repo-utils/-/repo-utils-0.3.7.tgz",
-      "integrity": "sha1-SrZq80DLEfp+XPgFgekr6Xwb964=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "get-value": "^2.0.6",
-        "git-config-path": "^1.0.1",
-        "is-absolute": "^0.2.6",
-        "kind-of": "^3.0.4",
-        "lazy-cache": "^2.0.1",
-        "mixin-deep": "^1.1.3",
-        "omit-empty": "^0.4.1",
-        "parse-author": "^1.0.0",
-        "parse-git-config": "^1.0.2",
-        "parse-github-url": "^0.3.2",
-        "project-name": "^0.2.6"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
     },
     "request": {
       "version": "2.88.2",
@@ -14010,101 +8377,10 @@
         "resolve-from": "^3.0.0"
       }
     },
-    "resolve-dir": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "requires": {
-        "expand-tilde": "^1.2.2",
-        "global-modules": "^0.2.3"
-      },
-      "dependencies": {
-        "expand-tilde": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-          "requires": {
-            "os-homedir": "^1.0.1"
-          }
-        }
-      }
-    },
-    "resolve-file": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/resolve-file/-/resolve-file-0.2.2.tgz",
-      "integrity": "sha1-FNvsWhnThPXW3GSin9ZigV0xdpY=",
-      "requires": {
-        "cwd": "^0.10.0",
-        "expand-tilde": "^2.0.1",
-        "extend-shallow": "^2.0.1",
-        "fs-exists-sync": "^0.1.0",
-        "global-modules": "^0.2.3",
-        "homedir-polyfill": "^1.0.0",
-        "lazy-cache": "^2.0.1",
-        "resolve": "^1.1.7"
-      },
-      "dependencies": {
-        "cwd": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
-          "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
-          "requires": {
-            "find-pkg": "^0.1.2",
-            "fs-exists-sync": "^0.1.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
-    },
     "resolve-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-    },
-    "resolve-glob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-glob/-/resolve-glob-1.0.0.tgz",
-      "integrity": "sha512-wSW9pVGJRs89k0wEXhM7C6+va9998NsDhgc0Y+6Nv8hrHsu0hUS7Ug10J1EiVtU6N2tKlSNvx9wLihL8Ao22Lg==",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-valid-glob": "^1.0.0",
-        "matched": "^1.0.2",
-        "relative": "^3.0.2",
-        "resolve-dir": "^1.0.0"
-      },
-      "dependencies": {
-        "global-modules": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-          "requires": {
-            "global-prefix": "^1.0.1",
-            "is-windows": "^1.0.1",
-            "resolve-dir": "^1.0.0"
-          }
-        },
-        "is-valid-glob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-          "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
-        },
-        "resolve-dir": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-          "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-          "requires": {
-            "expand-tilde": "^2.0.0",
-            "global-modules": "^1.0.0"
-          }
-        }
-      }
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -14119,52 +8395,10 @@
         "lowercase-keys": "^1.0.0"
       }
     },
-    "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
-      }
-    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-    },
-    "rethrow": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/rethrow/-/rethrow-0.2.3.tgz",
-      "integrity": "sha1-xVKPGQ6J7HU1iJRSob5omWtfZhY=",
-      "requires": {
-        "ansi-bgred": "^0.1.1",
-        "ansi-red": "^0.1.1",
-        "ansi-yellow": "^0.1.1",
-        "extend-shallow": "^1.1.4",
-        "lazy-cache": "^0.2.3",
-        "right-align": "^0.1.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-          "requires": {
-            "kind-of": "^1.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
-        },
-        "lazy-cache": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-        }
-      }
     },
     "retry": {
       "version": "0.12.0",
@@ -14206,14 +8440,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "requires": {
-        "once": "^1.3.0"
-      }
-    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -14221,11 +8447,6 @@
       "requires": {
         "aproba": "^1.1.1"
       }
-    },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -14349,9 +8570,13 @@
       }
     },
     "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "serve-index": {
       "version": "1.9.1",
@@ -14414,23 +8639,13 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
-    "set-getter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
-      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "requires": {
-        "to-object-path": "^0.3.0"
-      }
-    },
     "set-value": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-3.0.2.tgz",
+      "integrity": "sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==",
+      "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "is-plain-object": "^2.0.4"
       }
     },
     "setimmediate": {
@@ -14450,32 +8665,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "shallow-clone": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-      "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
-      "requires": {
-        "is-extendable": "^0.1.1",
-        "kind-of": "^2.0.1",
-        "lazy-cache": "^0.2.3",
-        "mixin-object": "^2.0.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-          "requires": {
-            "is-buffer": "^1.0.2"
-          }
-        },
-        "lazy-cache": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-        }
       }
     },
     "shebang-command": {
@@ -14688,24 +8877,6 @@
         "is-plain-obj": "^1.0.0"
       }
     },
-    "sort-object-arrays": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sort-object-arrays/-/sort-object-arrays-0.1.1.tgz",
-      "integrity": "sha1-mfVc8gWkkd3h9S8Jajaiawm0gy8=",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -14829,58 +9000,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
-    "src-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/src-stream/-/src-stream-0.1.1.tgz",
-      "integrity": "sha1-2T9G0oGjcAKB7A8wszoDFDiUpoE=",
-      "requires": {
-        "duplexify": "^3.4.2",
-        "merge-stream": "^0.1.8",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "merge-stream": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
-          "integrity": "sha1-SKB7O0oSHXSj7b/c20sIrb8CQLE=",
-          "requires": {
-            "through2": "^0.6.1"
-          },
-          "dependencies": {
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
-              }
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -14985,15 +9104,6 @@
         }
       }
     },
-    "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
-      }
-    },
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -15002,11 +9112,6 @@
         "end-of-stream": "^1.1.0",
         "stream-shift": "^1.0.0"
       }
-    },
-    "stream-exhaust": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
-      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw=="
     },
     "stream-http": {
       "version": "2.8.3",
@@ -15110,11 +9215,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "stringify-author": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/stringify-author/-/stringify-author-0.1.3.tgz",
-      "integrity": "sha1-1YHgLOC1XNo8lT5irdIR+uSw72Y="
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -15123,41 +9223,10 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
-    "strip-bom-buffer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/strip-bom-buffer/-/strip-bom-buffer-0.1.1.tgz",
-      "integrity": "sha1-yj3cSRnBP5/d8wsd/xAKmDUki00=",
-      "requires": {
-        "is-buffer": "^1.1.0",
-        "is-utf8": "^0.2.0"
-      }
-    },
-    "strip-bom-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-      "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-      "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "strip-bom": "^2.0.0"
-      }
-    },
     "strip-bom-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
-    },
-    "strip-color": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
-      "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s="
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -15228,11 +9297,6 @@
         "when": "~3.6.x"
       }
     },
-    "success-symbol": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
-      "integrity": "sha1-JAIuSG878c3KCUKDt2nEctO3KJc="
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -15293,162 +9357,10 @@
         }
       }
     },
-    "tableize-object": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tableize-object/-/tableize-object-0.1.0.tgz",
-      "integrity": "sha1-fCngEzsn1ItWuedtOijSQd8bOiQ=",
-      "requires": {
-        "isobject": "^2.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
-    },
-    "template-error": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/template-error/-/template-error-0.1.2.tgz",
-      "integrity": "sha1-GMn2ANkPLz37oIM+N/fLb0E1QtQ=",
-      "requires": {
-        "engine": "^0.1.5",
-        "kind-of": "^2.0.1",
-        "lazy-cache": "^0.2.3",
-        "rethrow": "^0.2.3"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-          "requires": {
-            "is-buffer": "^1.0.2"
-          }
-        },
-        "lazy-cache": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-        }
-      }
-    },
-    "templates": {
-      "version": "0.24.3",
-      "resolved": "https://registry.npmjs.org/templates/-/templates-0.24.3.tgz",
-      "integrity": "sha1-i6uicOGlcnR022hXX4Ic4bT+TQU=",
-      "requires": {
-        "array-sort": "^0.1.2",
-        "async-each": "^1.0.0",
-        "base": "^0.11.1",
-        "base-data": "^0.6.0",
-        "base-engines": "^0.2.0",
-        "base-helpers": "^0.1.1",
-        "base-option": "^0.8.3",
-        "base-plugins": "^0.4.13",
-        "base-routes": "^0.2.1",
-        "debug": "^2.2.0",
-        "deep-bind": "^0.3.0",
-        "define-property": "^0.2.5",
-        "engine-base": "^0.1.2",
-        "export-files": "^2.1.1",
-        "extend-shallow": "^2.0.1",
-        "falsey": "^0.3.0",
-        "get-value": "^2.0.6",
-        "get-view": "^0.1.1",
-        "group-array": "^0.3.0",
-        "has-glob": "^0.1.1",
-        "has-value": "^0.3.1",
-        "inflection": "^1.10.0",
-        "is-valid-app": "^0.2.0",
-        "layouts": "^0.11.0",
-        "lazy-cache": "^2.0.1",
-        "match-file": "^0.2.0",
-        "mixin-deep": "^1.1.3",
-        "paginationator": "^0.1.3",
-        "pascalcase": "^0.1.1",
-        "set-value": "^0.3.3",
-        "template-error": "^0.1.2",
-        "vinyl-item": "^0.1.0",
-        "vinyl-view": "^0.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.3.3.tgz",
-          "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "isobject": "^2.0.0",
-            "to-object-path": "^0.2.0"
-          }
-        },
-        "to-object-path": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz",
-          "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "is-arguments": "^1.0.2"
-          }
-        }
-      }
     },
     "term-size": {
       "version": "2.2.0",
@@ -15556,115 +9468,10 @@
         }
       }
     },
-    "through2-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-      "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-      "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
-      }
-    },
     "thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
-    },
-    "time-diff": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/time-diff/-/time-diff-0.3.1.tgz",
-      "integrity": "sha1-Jej7c07qnmy15LA5TwWBC5yHwtg=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^2.1.0",
-        "log-utils": "^0.1.0",
-        "pretty-time": "^0.2.0"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.1.0.tgz",
-          "integrity": "sha1-M0rDbNPq1wjeXGnhmpjRhkImtD8=",
-          "requires": {
-            "ansi-bgblack": "^0.1.1",
-            "ansi-bgblue": "^0.1.1",
-            "ansi-bgcyan": "^0.1.1",
-            "ansi-bggreen": "^0.1.1",
-            "ansi-bgmagenta": "^0.1.1",
-            "ansi-bgred": "^0.1.1",
-            "ansi-bgwhite": "^0.1.1",
-            "ansi-bgyellow": "^0.1.1",
-            "ansi-black": "^0.1.1",
-            "ansi-blue": "^0.1.1",
-            "ansi-bold": "^0.1.1",
-            "ansi-cyan": "^0.1.1",
-            "ansi-dim": "^0.1.1",
-            "ansi-gray": "^0.1.1",
-            "ansi-green": "^0.1.1",
-            "ansi-grey": "^0.1.1",
-            "ansi-hidden": "^0.1.1",
-            "ansi-inverse": "^0.1.1",
-            "ansi-italic": "^0.1.1",
-            "ansi-magenta": "^0.1.1",
-            "ansi-red": "^0.1.1",
-            "ansi-reset": "^0.1.1",
-            "ansi-strikethrough": "^0.1.1",
-            "ansi-underline": "^0.1.1",
-            "ansi-white": "^0.1.1",
-            "ansi-yellow": "^0.1.1",
-            "lazy-cache": "^0.2.4"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-        },
-        "log-utils": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.1.5.tgz",
-          "integrity": "sha1-3g84+Vf0zW69Xctoddijua4HT3c=",
-          "requires": {
-            "ansi-colors": "^0.1.0",
-            "error-symbol": "^0.1.0",
-            "info-symbol": "^0.1.0",
-            "log-ok": "^0.1.1",
-            "success-symbol": "^0.1.0",
-            "time-stamp": "^1.0.1",
-            "warning-symbol": "^0.1.0"
-          }
-        },
-        "pretty-time": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-0.2.0.tgz",
-          "integrity": "sha1-ejvexAScYgzXxCt/NCt01W5z104=",
-          "requires": {
-            "is-number": "^2.0.2",
-            "nanoseconds": "^0.1.0"
-          }
-        }
-      }
-    },
-    "time-stamp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
     },
     "timers-browserify": {
       "version": "2.0.11",
@@ -15690,27 +9497,10 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "optional": true
     },
-    "to-absolute-glob": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-      "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-      "requires": {
-        "extend-shallow": "^2.0.1"
-      }
-    },
     "to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
-    },
-    "to-choices": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/to-choices/-/to-choices-0.2.0.tgz",
-      "integrity": "sha1-IufnWgfWl9fkzsvVaxvwPBVlTXM=",
-      "requires": {
-        "ansi-gray": "^0.1.1",
-        "mixin-deep": "^1.1.3"
-      }
     },
     "to-factory": {
       "version": "1.0.0",
@@ -15721,68 +9511,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-    },
-    "to-file": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/to-file/-/to-file-0.2.0.tgz",
-      "integrity": "sha1-I2xsCIBl5XDe+9Fc9LTlZb5G6pM=",
-      "requires": {
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "file-contents": "^0.2.4",
-        "glob-parent": "^2.0.0",
-        "is-valid-glob": "^0.3.0",
-        "isobject": "^2.1.0",
-        "lazy-cache": "^2.0.1",
-        "vinyl": "^1.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
-      }
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -15883,14 +9611,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "trim-leading-lines": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/trim-leading-lines/-/trim-leading-lines-0.1.1.tgz",
-      "integrity": "sha1-DnysPoMELc+Vp07TaWbxd0TVwWk=",
-      "requires": {
-        "is-whitespace": "^0.3.0"
-      }
-    },
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
@@ -15969,11 +9689,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
     },
-    "unc-path-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
-    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -16007,6 +9722,16 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
+      },
+      "dependencies": {
+        "set-value": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-3.0.2.tgz",
+          "integrity": "sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
       }
     },
     "uniq": {
@@ -16033,26 +9758,6 @@
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "requires": {
         "imurmurhash": "^0.1.4"
-      }
-    },
-    "unique-stream": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
-      "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
-      "requires": {
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "through2-filter": "^3.0.0"
-      },
-      "dependencies": {
-        "through2-filter": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
-          "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-          "requires": {
-            "through2": "~2.0.0",
-            "xtend": "~4.0.0"
-          }
-        }
       }
     },
     "unique-string": {
@@ -16118,74 +9823,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
-    },
-    "update": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/update/-/update-0.7.4.tgz",
-      "integrity": "sha1-saCRwRo+KK4xui7vWLcRuCzpixQ=",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "assemble-core": "^0.25.0",
-        "assemble-loader": "^0.6.1",
-        "base-cli-process": "^0.1.18",
-        "base-config-process": "^0.1.9",
-        "base-generators": "^0.4.5",
-        "base-questions": "^0.7.3",
-        "base-runtimes": "^0.2.0",
-        "base-store": "^0.4.4",
-        "common-config": "^0.1.0",
-        "data-store": "^0.16.1",
-        "export-files": "^2.1.1",
-        "extend-shallow": "^2.0.1",
-        "find-pkg": "^0.1.2",
-        "fs-exists-sync": "^0.1.0",
-        "global-modules": "^0.2.2",
-        "gulp-choose-files": "^0.1.3",
-        "is-valid-app": "^0.2.0",
-        "isobject": "^2.1.0",
-        "lazy-cache": "^2.0.1",
-        "log-utils": "^0.2.1",
-        "parser-front-matter": "^1.4.1",
-        "resolve-dir": "^0.1.0",
-        "resolve-file": "^0.2.0",
-        "set-blocking": "^2.0.0",
-        "strip-color": "^0.1.0",
-        "text-table": "^0.2.0",
-        "through2": "^2.0.1",
-        "yargs-parser": "^2.4.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-          "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
-          }
-        }
-      }
     },
     "update-notifier": {
       "version": "4.1.0",
@@ -16382,11 +10019,6 @@
       "resolved": "https://registry.npmjs.org/v-runtime-template/-/v-runtime-template-1.10.0.tgz",
       "integrity": "sha512-WLlq9jUepSfUrMEenw3mn7FDXX6hhbl11JjC1OKhwLzifHzVrY5a696TUHDPyj9jke3GGnR7b+2T3od/RL5cww=="
     },
-    "vali-date": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -16405,291 +10037,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "vinyl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-      "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-      "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
-        "replace-ext": "0.0.1"
-      }
-    },
-    "vinyl-fs": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-      "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-      "requires": {
-        "duplexify": "^3.2.0",
-        "glob-stream": "^5.3.2",
-        "graceful-fs": "^4.0.0",
-        "gulp-sourcemaps": "1.6.0",
-        "is-valid-glob": "^0.3.0",
-        "lazystream": "^1.0.0",
-        "lodash.isequal": "^4.0.0",
-        "merge-stream": "^1.0.0",
-        "mkdirp": "^0.5.0",
-        "object-assign": "^4.0.0",
-        "readable-stream": "^2.0.4",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^1.0.0",
-        "through2": "^2.0.0",
-        "through2-filter": "^2.0.0",
-        "vali-date": "^1.0.0",
-        "vinyl": "^1.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "vinyl-item": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/vinyl-item/-/vinyl-item-0.1.0.tgz",
-      "integrity": "sha1-8ngTyBFC66ScpYSd5PQvb6Dl4Jg=",
-      "requires": {
-        "base": "^0.8.1",
-        "base-option": "^0.8.2",
-        "base-plugins": "^0.4.12",
-        "clone": "^1.0.2",
-        "clone-stats": "^1.0.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "isobject": "^2.1.0",
-        "lazy-cache": "^2.0.1",
-        "vinyl": "^1.1.1"
-      },
-      "dependencies": {
-        "base": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/base/-/base-0.8.1.tgz",
-          "integrity": "sha1-aQC7MA8sdZbJnz2DurhyLYGLdI8=",
-          "requires": {
-            "arr-union": "^3.1.0",
-            "cache-base": "^0.8.2",
-            "class-utils": "^0.3.2",
-            "component-emitter": "^1.2.0",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "lazy-cache": "^1.0.3",
-            "mixin-deep": "^1.1.3"
-          },
-          "dependencies": {
-            "lazy-cache": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-            }
-          }
-        },
-        "cache-base": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-0.8.5.tgz",
-          "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
-          "requires": {
-            "collection-visit": "^0.2.1",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.5",
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0",
-            "lazy-cache": "^2.0.1",
-            "set-value": "^0.4.2",
-            "to-object-path": "^0.3.0",
-            "union-value": "^0.2.3",
-            "unset-value": "^0.1.1"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-            }
-          }
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-        },
-        "collection-visit": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
-          "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
-          "requires": {
-            "lazy-cache": "^2.0.1",
-            "map-visit": "^0.1.5",
-            "object-visit": "^0.3.4"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        },
-        "map-visit": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
-          "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
-          "requires": {
-            "lazy-cache": "^2.0.1",
-            "object-visit": "^0.3.4"
-          }
-        },
-        "object-visit": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
-          "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
-          "requires": {
-            "isobject": "^2.0.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        },
-        "union-value": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
-          "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
-          "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
-          }
-        },
-        "unset-value": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
-          "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
-          "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-            }
-          }
-        }
-      }
-    },
-    "vinyl-view": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/vinyl-view/-/vinyl-view-0.1.2.tgz",
-      "integrity": "sha1-CaxtfIASEr8JJr2dQQb0XmxPyXc=",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "engine-base": "^0.1.2",
-        "isobject": "^2.1.0",
-        "lazy-cache": "^2.0.1",
-        "mixin-deep": "^1.1.3",
-        "vinyl-item": "^0.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "^0.1.0"
-          }
-        }
       }
     },
     "vm-browserify": {
@@ -16759,6 +10106,14 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "requires": {
+            "randombytes": "^2.1.0"
           }
         },
         "source-map": {
@@ -16883,11 +10238,6 @@
       "requires": {
         "smoothscroll-polyfill": "^0.4.3"
       }
-    },
-    "warning-symbol": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/warning-symbol/-/warning-symbol-0.1.0.tgz",
-      "integrity": "sha1-uzHdEbeg+dZ6su2V9Fe2WCW7rSE="
     },
     "watchpack": {
       "version": "1.6.1",
@@ -17408,14 +10758,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "requires": {
-        "mkdirp": "^0.5.1"
-      }
-    },
     "write-file-atomic": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
@@ -17425,14 +10767,6 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "write-json": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/write-json/-/write-json-0.2.2.tgz",
-      "integrity": "sha1-+k4VKennY6T5LwfZhBMX49JI2vM=",
-      "requires": {
-        "write": "^0.2.1"
       }
     },
     "ws": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Theme for VuePress static site generator used by Tendermint and Cosmos projects.",
   "main": "index.js",
   "scripts": {
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "preinstall": "npx npm-force-resolutions"
   },
   "repository": {
     "type": "git",
@@ -22,8 +23,8 @@
   "license": "Apache 2.0",
   "dependencies": {
     "@cosmos-ui/vue": "^0.33.0",
-    "algoliasearch": "^4.2.0",
     "@vuepress/plugin-google-analytics": "1.5.3",
+    "algoliasearch": "^4.2.0",
     "axios": "^0.19.2",
     "cheerio": "^1.0.0-rc.3",
     "clipboard-copy": "^3.1.0",
@@ -41,12 +42,17 @@
     "stylus": "^0.54.8",
     "stylus-loader": "^3.0.2",
     "tiny-cookie": "^2.3.2",
-    "update": "^0.7.4",
     "v-runtime-template": "^1.10.0",
     "vuepress": "1.5.3",
     "vuepress-plugin-sitemap": "^2.3.1"
   },
   "devDependencies": {
+    "serialize-javascript": "^4.0.0",
+    "set-value": "^3.0.2",
     "watchpack": "1.6.1"
+  },
+  "resolutions": {
+    "serialize-javascript": "^4.0.0",
+    "set-value": "^3.0.2"
   }
 }


### PR DESCRIPTION
closes https://github.com/cosmos/vuepress-theme-cosmos/issues/95

* remove `update` from dep
* fix `update` dep with `set-value`
* fix `serialize-javascript`

```                         
cyrusgoh vuepress-theme-cosmos (cyrus/dep-fix|✔) npm audit       
                                                                                
                       === npm audit security report ===                        
                                                                                
found 0 vulnerabilities
 in 1337 scanned packages
```