### PR TITLE
Bump copy-webpack-plugin 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3349,9 +3349,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "copy-webpack-plugin": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
-      "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
+      "integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
       "requires": {
         "cacache": "^12.0.3",
         "find-cache-dir": "^2.1.0",
@@ -3363,7 +3363,7 @@
         "normalize-path": "^3.0.0",
         "p-limit": "^2.2.1",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^4.0.0",
         "webpack-log": "^2.0.0"
       },
       "dependencies": {
@@ -8550,9 +8550,12 @@
       }
     },
     "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "serve-index": {
       "version": "1.9.1",


### PR DESCRIPTION
Closes: #95 

```
cyrusgoh vuepress-theme-cosmos (develop|✔) npm audit fix
npm WARN vuepress-theme-cosmos@1.0.172 license should be a valid SPDX license expression

updated 2 packages in 4.988s
fixed 1 of 1 vulnerability in 1335 scanned packages
cyrusgoh vuepress-theme-cosmos (develop|✚1) npm audit

                       === npm audit security report ===

found 0 vulnerabilities
 in 1335 scanned packages
```

______

For contributor use:

- [ ] Linked to relevant Github issues
- [ ] Provided a description
- [ ] Added a relevant changelog
- [ ] Re-reviewed `Files changed`

______

For admin use:

- [x] Checked errors / warnings on console
- [x] Ran `npm run build` in the local dev repo to make sure it compiles without any errors
- [ ] When bumping version, made sure `package-lock.json` has the latest version
