### PR TITLE
Versioning

### DIFF
--- a/global-components/Homepage.vue
+++ b/global-components/Homepage.vue
@@ -1,10 +1,12 @@
 <template lang="pug">
   div
     .search__container
-      .search(@click="$emit('search', true)" v-if="$themeConfig.algolia")
-        .search__icon
-          icon-search
-        .search__text Search
+      .search__container__right
+        tm-select-version
+        .search(@click="$emit('search', true)" v-if="$themeConfig.algolia")
+          .search__icon
+            icon-search
+          .search__text Search
     .h1 {{$frontmatter.title}}
     .intro
       .p {{$frontmatter.description}}
@@ -58,8 +60,7 @@
   display flex
   align-items center
   color rgba(22, 25, 49, 0.65)
-  padding-top 1rem
-  width calc(var(--aside-width) - 6rem)
+  //- width calc(var(--aside-width) - 6rem)
   cursor pointer
   transition color .15s ease-out
 
@@ -71,6 +72,12 @@
     justify-content flex-end
     margin-top 1rem
     margin-bottom 1rem
+    padding-top 1rem
+
+    &__right
+      display grid
+      grid-auto-flow column
+      gap 2rem
 
   &__icon
     width 1.5rem

--- a/global-components/TmAside.vue
+++ b/global-components/TmAside.vue
@@ -2,6 +2,7 @@
   div
     .container
       .search__container
+        tm-select-version(v-if="$themeConfig.versions")
         .search(@click="$emit('search', true)")
           .search__icon
             icon-search
@@ -25,7 +26,7 @@
 
 .search__container
   display flex
-  justify-content flex-start
+  justify-content space-between
   padding-top 0.5rem
   padding-bottom 3.5rem
 

--- a/global-components/TmSelectVersion.vue
+++ b/global-components/TmSelectVersion.vue
@@ -1,15 +1,18 @@
 <template lang="pug">
   div
-    .select(v-if="versions.length > 1")
-      select(@input="select")
-        option(v-for="item in versions" :value="item") {{item}}
+    .container
+      .select(v-if="versions.length > 1")
+        select(@input="select")
+          option(v-for="item in versions" :value="item") {{item}}
 </template>
 
 <style lang="stylus" scoped>
+.container
+  padding-left 0.75rem
+
 select
   border none
   background none
-  text-transform uppercase
   letter-spacing 0.03em
   font-weight 600
   font-size 0.875rem
@@ -19,6 +22,7 @@ select
   padding 0.25rem 0.5rem
   border-radius 6px
   background-color transparent
+  width fit-content
 </style>
 
 <script>
@@ -30,9 +34,21 @@ export default {
   },
   methods: {
     select(e) {
-      // this.$router.push(
-      //   this.$page.path.replace(this.$localeConfig.path, e.target.value)
-      // );
+      // console.log(e.target.value)
+      if (e.target.value === 'master') {
+        this.$router.push(
+          this.$page.path.replace(this.$site.base, e.target.value + '/introduction/quick-start.html')
+        )
+      } else {
+        this.$router.push(
+          this.$page.path.replace(this.$site.base, e.target.value + '/docs/DOCS_README.html')
+        )
+      }
+      // if (e.targate.value === 'master') {
+      //   this.$router.push(
+      //     this.$page.path.replace(this.$localeConfig.path, e.target.value)
+      //   );
+      // }
     }
   }
 };

--- a/global-components/TmSelectVersion.vue
+++ b/global-components/TmSelectVersion.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   div
     .container
-      .select(v-if="versions.length > 1")
+      .select(v-if="versions")
         select(@input="select")
           option(v-for="item in versions" :value="item") {{item}}
 </template>

--- a/global-components/TmSelectVersion.vue
+++ b/global-components/TmSelectVersion.vue
@@ -34,21 +34,7 @@ export default {
   },
   methods: {
     select(e) {
-      // console.log(e.target.value)
-      if (e.target.value === 'master') {
-        this.$router.push(
-          this.$page.path.replace(this.$site.base, e.target.value + '/introduction/quick-start.html')
-        )
-      } else {
-        this.$router.push(
-          this.$page.path.replace(this.$site.base, e.target.value + '/docs/DOCS_README.html')
-        )
-      }
-      // if (e.targate.value === 'master') {
-      //   this.$router.push(
-      //     this.$page.path.replace(this.$localeConfig.path, e.target.value)
-      //   );
-      // }
+      this.$router.push({ path: `/${e.target.value}` })
     }
   }
 };

--- a/global-components/TmSelectVersion.vue
+++ b/global-components/TmSelectVersion.vue
@@ -34,6 +34,9 @@ select
   &:focus
     outline none
 
+  &:hover
+    cursor pointer
+
 .select
   padding 0.5rem 0
   background-color transparent

--- a/global-components/TmSelectVersion.vue
+++ b/global-components/TmSelectVersion.vue
@@ -6,25 +6,6 @@
           option(v-for="item in versions" :value="item") {{item}}
 </template>
 
-<style lang="stylus" scoped>
-.container
-  padding-left 0.75rem
-
-select
-  border none
-  background none
-  letter-spacing 0.03em
-  font-weight 600
-  font-size 0.875rem
-
-.select
-  border 2px solid rgba(140, 145, 177, 0.32)
-  padding 0.25rem 0.5rem
-  border-radius 6px
-  background-color transparent
-  width fit-content
-</style>
-
 <script>
 export default {
   computed: {
@@ -39,3 +20,22 @@ export default {
   }
 };
 </script>
+
+<style lang="stylus" scoped>
+select
+  border none
+  background none
+  letter-spacing 0.03em
+  font-weight 600
+  font-size 0.875rem
+  line-height 1.25rem
+  color rgba(0, 0, 0, 0.667)
+
+  &:focus
+    outline none
+
+.select
+  padding 0.5rem 0
+  background-color transparent
+  width fit-content
+</style>

--- a/global-components/TmSidebarContent.vue
+++ b/global-components/TmSidebarContent.vue
@@ -13,6 +13,8 @@
           .title {{item.title}}
           client-only
             tm-sidebar-tree(:value="item.children" v-if="item.children" :tree="tree" :level="0").section
+        .sidebar.version
+          tm-select-version
       .footer(:class="[`footer__compact__${!!(compact === true)}`]" v-if="!$themeConfig.custom")
         a(:href="product.url" target="_blank" rel="noreferrer noopener" v-for="product in products" :style="{'--color': product.color}" v-if="$themeConfig.label != product.label").footer__item
           component(:is="`tm-logo-${product.label}`").footer__item__icon
@@ -70,6 +72,10 @@
   padding-left 2rem
   padding-right 2rem
   overflow-x hidden
+
+.version
+  margin-top 2rem
+  display none
 
 .items
   flex-grow 1
@@ -136,6 +142,10 @@
       text-align center
       font-size 0.6875rem
       line-height 0.875rem
+
+@media screen and (max-width: 1135px)
+  .version
+    display block
 </style>
 
 <script>

--- a/layouts/GlobalLayout.vue
+++ b/layouts/GlobalLayout.vue
@@ -11,6 +11,7 @@
         .layout__main__content(:class="[`aside__${!($frontmatter.aside === false)}`]")
           .layout__main__content__body(id="content-scroll")
             .layout__main__content__body__breadcrumbs(v-if="!($frontmatter.aside === false)")
+              tm-select-version
               tm-breadcrumbs(@visible="rsidebarVisible = $event")
             .layout__main__content__body__wrapper
               component(:is="layout" :key="$route.path" @search="searchPanel = $event" @prereq="prereq = $event")

--- a/layouts/GlobalLayout.vue
+++ b/layouts/GlobalLayout.vue
@@ -11,7 +11,6 @@
         .layout__main__content(:class="[`aside__${!($frontmatter.aside === false)}`]")
           .layout__main__content__body(id="content-scroll")
             .layout__main__content__body__breadcrumbs(v-if="!($frontmatter.aside === false)")
-              tm-select-version
               tm-breadcrumbs(@visible="rsidebarVisible = $event")
             .layout__main__content__body__wrapper
               component(:is="layout" :key="$route.path" @search="searchPanel = $event" @prereq="prereq = $event")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1141,9 +1141,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.5.tgz",
-      "integrity": "sha512-gyTcvz7JFa4V45C0Zklv//GmFOAal5fL23OWpBLqc4nZ4Yrz67s4kCNwSK1Gu0MXGTU8mRY3zJYtacLdKXlzig==",
+      "version": "7.12.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
+      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "lodash": "^4.17.19",
@@ -1263,9 +1263,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "14.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
-      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
+      "version": "14.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -2153,25 +2153,15 @@
       }
     },
     "babel-loader": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
-      "integrity": "sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.1.tgz",
+      "integrity": "sha512-dMF8sb2KQ8kJl21GUjkW1HWmcsL39GOV5vnzjqrCzEPNY0S0UfMLnumidiwIajDSBmKhYf5iRW+HXaM4cvCKBw==",
       "requires": {
         "find-cache-dir": "^2.1.0",
         "loader-utils": "^1.4.0",
-        "mkdirp": "^0.5.3",
+        "make-dir": "^2.1.0",
         "pify": "^4.0.1",
         "schema-utils": "^2.6.5"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -2270,9 +2260,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "batch": {
       "version": "0.6.1",
@@ -2535,19 +2525,12 @@
       }
     },
     "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
       "requires": {
-        "bn.js": "^4.1.0",
+        "bn.js": "^5.0.0",
         "randombytes": "^2.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        }
       }
     },
     "browserify-sign": {
@@ -2575,14 +2558,15 @@
       }
     },
     "browserslist": {
-      "version": "4.14.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.6.tgz",
-      "integrity": "sha512-zeFYcUo85ENhc/zxHbiIp0LGzzTrE2Pv2JhxvS7kpUb9Q9D38kUX6Bie7pGutJ/5iF5rOxE7CepAuWD56xJ33A==",
+      "version": "4.14.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
+      "integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001154",
-        "electron-to-chromium": "^1.3.585",
+        "caniuse-lite": "^1.0.30001157",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.591",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.65"
+        "node-releases": "^1.1.66"
       }
     },
     "buffer": {
@@ -2819,9 +2803,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001154",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001154.tgz",
-      "integrity": "sha512-y9DvdSti8NnYB9Be92ddMZQrcOe04kcQtcxtBx4NkB04+qZ+JUWotnXBJTmxlKudhxNTQ3RRknMwNU2YQl/Org=="
+      "version": "1.0.30001157",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz",
+      "integrity": "sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -3344,16 +3328,16 @@
       }
     },
     "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.7.0.tgz",
+      "integrity": "sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA=="
     },
     "core-js-compat": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
-      "integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.7.0.tgz",
+      "integrity": "sha512-V8yBI3+ZLDVomoWICO6kq/CD28Y4r1M7CWeO4AGpMdMfseu8bkSubBmUPySMGKRTS+su4XQ07zUkAsiu9FCWTg==",
       "requires": {
-        "browserslist": "^4.8.5",
+        "browserslist": "^4.14.6",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -3651,9 +3635,9 @@
       },
       "dependencies": {
         "css-tree": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0.tgz",
-          "integrity": "sha512-CdVYz/Yuqw0VdKhXPBIgi8DO3NicJVYZNWeX9XcIuSp9ZoFT5IcleVRW07O5rMjdcx1mb+MEJPknTTEW7DdsYw==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.1.tgz",
+          "integrity": "sha512-WroX+2MvsYcRGP8QA0p+rxzOniT/zpAoQ/DTKDSJzh5T3IQKUkFHeIIfgIapm2uaP178GWY3Mime1qbk8GO/tA==",
           "requires": {
             "mdn-data": "2.0.12",
             "source-map": "^0.6.1"
@@ -4099,9 +4083,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.586",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.586.tgz",
-      "integrity": "sha512-or8FCbQCRlPZHkOoqBULOI9hzTiStVIQqDLgAPt8pzY+swTrW+89vsqd24Zn+Iv4guAJLxRBD6OR5AmbpabGDA=="
+      "version": "1.3.594",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.594.tgz",
+      "integrity": "sha512-mEax1P0CcoZJtXQU7OA0dO5nHiAQWw8gRGWKhnUyPA9bJW0B/JGiaQB+vtK66Ovm6U9qPxe2iXbO1L+f4jJAiw=="
     },
     "elliptic": {
       "version": "6.5.3",
@@ -5559,9 +5543,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
-      "integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+      "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -6651,9 +6635,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.65",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.65.tgz",
-      "integrity": "sha512-YpzJOe2WFIW0V4ZkJQd/DGR/zdVwc/pI4Nl1CZrBO19FdRcSTmsuhdttw9rsTzzJLrNcSloLiBbEYx1C4f6gpA=="
+      "version": "1.1.66",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.66.tgz",
+      "integrity": "sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg=="
     },
     "nopt": {
       "version": "1.0.10",
@@ -8209,9 +8193,9 @@
       }
     },
     "registry-auth-token": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
-      "integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
       "requires": {
         "rc": "^1.2.8"
       }
@@ -8326,11 +8310,11 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-      "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
       "requires": {
-        "is-core-module": "^2.0.0",
+        "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -10075,9 +10059,9 @@
       }
     },
     "vue-router": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.4.8.tgz",
-      "integrity": "sha512-3BsR84AqarcmweXjItxw3jwQsiYNssYg090yi4rlzTnCJxmHtkyCvhNz9Z7qRSOkmiV485KkUCReTp5AjNY4wg=="
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.4.9.tgz",
+      "integrity": "sha512-CGAKWN44RqXW06oC+u4mPgHLQQi2t6vLD/JbGRDAXm0YpMv0bgpKuU5bBd7AvMgfTz9kXVRIWKHqRwGEb8xFkA=="
     },
     "vue-server-renderer": {
       "version": "2.6.12",
@@ -10262,9 +10246,9 @@
       }
     },
     "watchpack-chokidar2": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
-      "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+      "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
       "optional": true,
       "requires": {
         "chokidar": "^2.1.8"
@@ -10435,14 +10419,14 @@
           }
         },
         "watchpack": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
-          "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+          "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
           "requires": {
             "chokidar": "^3.4.1",
             "graceful-fs": "^4.1.2",
             "neo-async": "^2.5.0",
-            "watchpack-chokidar2": "^2.0.0"
+            "watchpack-chokidar2": "^2.0.1"
           }
         }
       }


### PR DESCRIPTION
Blocked by: @nassdonald's design for the version switcher.

- [x] fetch versioned docs using Makefile / ~~cloning branch's docs in pre.sh~~
   - [x] makefile cosmos-sdk https://github.com/cosmos/cosmos-sdk/pull/7413/files
   - [x] makefile tendermint https://github.com/tendermint/tendermint/pull/5467
- [x] design for version switcher
- [x] implement version switcher in docs theme

Related: https://github.com/allinbits/design/issues/335

- uses router push to switch version
- user must add an array of versions to themeConfig in .vuepress/config.js in order to use version switcher
- unable to test it locally even after using make build-docs to generate different versions in ~/output locally

______

For contributor use:

- [ ] Linked to relevant Github issues
- [ ] Provided a description
- [ ] Added a relevant changelog
- [ ] Re-reviewed `Files changed`

______

For admin use:

- [x] Checked errors / warnings on console
- [x] Ran `npm run build` in the local dev repo to make sure it compiles without any errors
- [x] When bumping version, made sure `package-lock.json` has the latest version
