### PR TITLE
Replace jetbrains mono font files with jsdelivr cdn

### DIFF
--- a/styles/index.styl
+++ b/styles/index.styl
@@ -21,10 +21,9 @@
 
 @font-face
     font-family 'JetBrains Mono'
-    src url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/web/eot/JetBrainsMono-Regular.eot') format('embedded-opentype'),
-         url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/web/woff2/JetBrainsMono-Regular.woff2') format('woff2'),
-         url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/web/woff/JetBrainsMono-Regular.woff') format('woff'),
-         url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/ttf/JetBrainsMono-Regular.ttf') format('truetype')
+    src url('https://cdn.jsdelivr.net/gh/JetBrains/JetBrainsMono/web/woff2/JetBrainsMono-Regular.woff2') format('woff2'),
+        url('https://cdn.jsdelivr.net/gh/JetBrains/JetBrainsMono/web/woff/JetBrainsMono-Regular.woff') format('woff'),
+        url('https://cdn.jsdelivr.net/gh/JetBrains/JetBrainsMono/ttf/JetBrainsMono-Regular.ttf') format('truetype')
     font-weight normal
     font-style normal
 


### PR DESCRIPTION
Closes: https://github.com/cosmos/vuepress-theme-cosmos/issues/122

## Description

The file structure of the source code `JetBrains/JetBrainsMono` has changed. Replaced the font files with [jsdelivr cdn ](https://www.jsdelivr.com/?docs=gh)

- replaced woff2, woff, ttf
- removed eot

______

For contributor use:

- [ ] Linked to relevant Github issues
- [ ] Provided a description
- [ ] Added a relevant changelog
- [ ] Re-reviewed `Files changed`

______

For admin use:

- [ ] Checked errors / warnings on console
- [ ] Ran `npm run build` in the local dev repo to make sure it compiles without any errors
- [ ] When bumping version, made sure `package-lock.json` has the latest version
