### PR TITLE
Deprecate fuse.js

### DIFF
--- a/global-components/Homepage.vue
+++ b/global-components/Homepage.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   div
     .search__container
-      .search(@click="$emit('search', true)")
+      .search(@click="$emit('search', true)" v-if="$themeConfig.algolia")
         .search__icon
           icon-search
         .search__text Search

--- a/global-components/SectionSearch.vue
+++ b/global-components/SectionSearch.vue
@@ -264,15 +264,15 @@ strong
 
 <script>
 import { find, last, debounce } from "lodash";
-import Fuse from "fuse.js";
+//- import Fuse from "fuse.js";
 
 export default {
   props: ["visible", "query"],
   data: function() {
     return {
       searchResults: null,
-      searchQuery: null,
-      fuse: null,
+      //- searchQuery: null,
+      //- fuse: null,
     };
   },
   watch: {
@@ -303,33 +303,33 @@ export default {
         return;
       }
     });
-    const fuseIndex = this.$site.pages
-      .map((doc) => {
-        return {
-          key: doc.key,
-          title: doc.title,
-          headers: doc.headers && doc.headers.map((h) => h.title).join(" "),
-          // description: doc.frontmatter && doc.frontmatter.description,
-          path: doc.path,
-        };
-      })
-      .filter((doc) => {
-        return !(
-          Object.keys(this.$site.locales || {}).indexOf(
-            doc.path.split("/")[1]
-          ) > -1
-        );
-      });
-    const fuseOptions = {
-      keys: ["title", "headers", "description", "path"],
-      shouldSort: true,
-      includeScore: true,
-      includeMatches: true,
-      threshold: 1,
-    };
-    this.fuse = new Fuse(fuseIndex, fuseOptions);
+    //- const fuseIndex = this.$site.pages
+    //-   .map((doc) => {
+    //-     return {
+    //-       key: doc.key,
+    //-       title: doc.title,
+    //-       headers: doc.headers && doc.headers.map((h) => h.title).join(" "),
+    //-       // description: doc.frontmatter && doc.frontmatter.description,
+    //-       path: doc.path,
+    //-     };
+    //-   })
+    //-   .filter((doc) => {
+    //-     return !(
+    //-       Object.keys(this.$site.locales || {}).indexOf(
+    //-         doc.path.split("/")[1]
+    //-       ) > -1
+    //-     );
+    //-   });
+    //- const fuseOptions = {
+    //-   keys: ["title", "headers", "description", "path"],
+    //-   shouldSort: true,
+    //-   includeScore: true,
+    //-   includeMatches: true,
+    //-   threshold: 1,
+    //- };
+    //- this.fuse = new Fuse(fuseIndex, fuseOptions);
     if (this.$refs.search) this.$refs.search.focus();
-    this.search();
+    //- this.search();
   },
   methods: {
     resultTitle(result) {
@@ -358,16 +358,16 @@ export default {
       );
       if (headers && headers.length) return headers[0];
     },
-    search(e) {
-      if (!this.query) return;
-      const fuse = this.fuse.search(this.query).map((result) => {
-        return {
-          ...result,
-          item: find(this.$site.pages, { key: result.item.key }),
-        };
-      });
-      this.searchResults = fuse;
-    },
+    //- search(e) {
+    //-   if (!this.query) return;
+    //-   const fuse = this.fuse.search(this.query).map((result) => {
+    //-     return {
+    //-       ...result,
+    //-       item: find(this.$site.pages, { key: result.item.key }),
+    //-     };
+    //-   });
+    //-   this.searchResults = fuse;
+    //- },
     itemByKey(key) {
       return find(this.$site.pages, { key });
     },

--- a/global-components/TmAside.vue
+++ b/global-components/TmAside.vue
@@ -2,7 +2,7 @@
   div
     .container
       .search__container
-        .search(@click="$emit('search', true)")
+        .search(@click="$emit('search', true)" v-if="$themeConfig.algolia")
           .search__icon
             icon-search
           .search__text Search

--- a/package-lock.json
+++ b/package-lock.json
@@ -4863,11 +4863,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
-    "fuse.js": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.4.1.tgz",
-      "integrity": "sha512-+hAS7KYgLXontDh/vqffs7wIBw0ceb9Sx8ywZQhOsiQGcSO5zInGhttWOUYQYlvV/yYMJOacQ129Xs3mP3+oZQ=="
-    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "clipboard-copy": "^3.1.0",
     "entities": "2.0.2",
     "esm": "^3.2.25",
-    "fuse.js": "6.4.1",
     "gray-matter": "^4.0.2",
     "hotkeys-js": "3.8.1",
     "jsonp": "^0.2.1",

--- a/readme.md
+++ b/readme.md
@@ -146,9 +146,9 @@ Setting `order: false` removes the item (file or directory) from the sidebar. It
 
 ## Docs search
 
-The search bar is currently using Fuse.js by default. We have since integrated with [Algolia Docsearch](https://github.com/cosmos/vuepress-theme-cosmos/pull/48) to improve the search experience. In order to use Algolia Docssearch, you're required to [join the program](https://docsearch.algolia.com). Once you have acquired all the necessary Algolia config keys, you can modify the themeConfig.algolia in the `config.js` as such:
+We're currently using [Algolia Docsearch](https://github.com/cosmos/vuepress-theme-cosmos/pull/48) to improve the search experience. You're required to [join the program](https://docsearch.algolia.com) to use Algolia Docssearch. Once you have acquired all the necessary Algolia config keys, you can modify the `$themeConfig.algolia` in the `config.js` as such:
 
-```
+```json
 algolia: {
   id: "BH4D9OD16A",
   key: "ac317234e6a42074175369b2f42e9754",


### PR DESCRIPTION
- enable .search only when themeConfig.algolia exists
- remove `fuse.js`

Related: https://github.com/allinbits/design/issues/335

## Description

______

For contributor use:

- [ ] Linked to relevant Github issues
- [ ] Provided a description
- [ ] Added a relevant changelog
- [ ] Re-reviewed `Files changed`

______

For admin use:

- [x] Checked errors / warnings on console
- [ ] Ran `npm run build` in the local dev repo to make sure it compiles without any errors
- [x] When bumping version, made sure `package-lock.json` has the latest version
