### PR TITLE
Prism: Python syntax support

### DIFF
--- a/global-components/TmCodeBlock.vue
+++ b/global-components/TmCodeBlock.vue
@@ -407,6 +407,7 @@ import "prismjs/components/prism-bash.min.js";
 import "prismjs/components/prism-json.min.js";
 import "prismjs/components/prism-protobuf.min.js";
 import "prismjs/components/prism-solidity.min.js";
+import "prismjs/components/prism-python.min.js";
 import copy from "clipboard-copy";
 import { Base64 } from "js-base64";
 

--- a/readme.md
+++ b/readme.md
@@ -155,13 +155,17 @@ Setting `order: false` removes the item (file or directory) from the sidebar. It
 
 We're currently using [Algolia Docsearch](https://github.com/cosmos/vuepress-theme-cosmos/pull/48) to improve the search experience. You're required to [join the program](https://docsearch.algolia.com) to use Algolia Docssearch. Once you have acquired all the necessary Algolia config keys, you can modify the `$themeConfig.algolia` in the `config.js` as such:
 
-```json
+```js
 algolia: {
   id: "BH4D9OD16A",
   key: "ac317234e6a42074175369b2f42e9754",
   index: "cosmos-sdk"
 },
 ```
+
+## Syntax highlighter
+
+`vuepress-theme-cosmos` uses [Prism](https://prismjs.com/) to highlight language syntax in Markdown code blocks. Modify the manually imported files in `TmCodeBlock.vue` to [support different languages](https://prismjs.com/#supported-languages).
 
 ## Used by
 


### PR DESCRIPTION
Closes: https://github.com/cosmos/vuepress-theme-cosmos/issues/154

## Description

- added `prism-python.min.js` to tm-code-block
______

For contributor use:

- [ ] Linked to relevant Github issues
- [ ] Provided a description
- [ ] Added a relevant changelog
- [ ] Re-reviewed `Files changed`

______

For admin use:

- [ ] Checked errors / warnings on console
- [ ] Ran `npm run build` in the local dev repo to make sure it compiles without any errors
- [ ] When bumping version, made sure `package-lock.json` has the latest version
