### PR TITLE
1.0.179

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,7 +1,0 @@
-version: 1
-update_configs:
-  # Keep package.json (& lockfiles) up to date as soon as
-  # new versions are published to the npm registry
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "live"

--- a/global-components/TmSelectVersion.vue
+++ b/global-components/TmSelectVersion.vue
@@ -3,7 +3,7 @@
     .container
       .select(v-if="versions")
         select(@input="versionChange($event.target.value)")
-          option(value="" selected disabled hidden) Versions
+          option(value="" selected disabled hidden) Version
           option(v-for="item in versions" :value="item.key") {{ item.label }}
 </template>
 

--- a/global-components/TmSelectVersion.vue
+++ b/global-components/TmSelectVersion.vue
@@ -1,6 +1,7 @@
 <template lang="pug">
   div
     .container
+      span.sr-only Docs Version Switcher
       .select(v-if="versions")
         select(@input="versionChange($event.target.value)")
           option(value="" selected disabled hidden) Version
@@ -27,14 +28,31 @@ export default {
 </script>
 
 <style lang="stylus" scoped>
+// Accessible/SEO friendly CSS hiding
+.sr-only
+  position absolute
+  height 1px
+  width 1px
+  overflow hidden
+  clip rect(1px, 1px, 1px, 1px)
+
 select
   border none
-  background none
   letter-spacing 0.03em
   font-weight 600
   font-size 0.875rem
   line-height 1.25rem
   color rgba(0, 0, 0, 0.667)
+  padding 0.5rem 0
+  max-width 100%
+  box-sizing border-box
+  appearance none
+  background none
+  background-image url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2.5 5L8 10.5L13.5 5' stroke='black' stroke-opacity='0.667' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E%0A")
+  background-repeat no-repeat, repeat
+  background-position right .7em top 50%, 0 0
+  background-size .75em auto, 100%
+  padding-right 1.75rem
 
   &:focus
     outline none
@@ -43,7 +61,6 @@ select
     cursor pointer
 
 .select
-  padding 0.5rem 0
   background-color transparent
   width fit-content
 </style>

--- a/global-components/TmSelectVersion.vue
+++ b/global-components/TmSelectVersion.vue
@@ -15,7 +15,7 @@ export default {
       selectedItem: "",
     }
   },
-  created() {
+  mounted() {
     const emptyVal = ""
     const pathName = window.location.pathname.replace("/", "")
     const pathRe = /[a-zA-Z]{1}\d+(\.\d+)+/g

--- a/global-components/TmSelectVersion.vue
+++ b/global-components/TmSelectVersion.vue
@@ -3,22 +3,58 @@
     .container
       span.sr-only Docs Version Switcher
       .select(v-if="versions")
-        select(@input="versionChange($event.target.value)")
-          option(value="" selected disabled hidden) Version
+        select(@input="versionChange($event.target.value)" v-model="selectedItem")
+          option(value="" disabled) Version
           option(v-for="item in versions" :value="item.key") {{ item.label }}
 </template>
 
 <script>
 export default {
+  data() {
+    return {
+      selectedItem: "",
+    }
+  },
+  created() {
+    const emptyVal = ""
+    const pathName = window.location.pathname.replace("/", "")
+    const pathRe = /[a-zA-Z]{1}\d+(\.\d+)+/g
+    const versionPathName = window.location.href.match(pathRe)
+
+    // match values in select option
+    // e.g. http://docs.cosmos.network/master
+    if (this.versionValue === this.versionValue) {
+      // check if input has a pathname
+      // extract version number from string
+      // point to the selectedItem
+      // e.g. https://docs.cosmos.network/v0.39/intro/overview.html
+      if (versionPathName !== null) {
+        this.selectedItem = versionPathName[0]
+      } else {
+        this.selectedItem = pathName
+      }
+    }
+    // e.g. http://docs.cosmos.network
+    else {
+      this.selectedItem = emptyVal
+    }
+  },
   computed: {
     versions() {
       return this.$themeConfig.versions;
+    },
+    versionValue() {
+      for (var key in this.versions) {
+        var value = this.versions[key];
+
+        return value.key
+      }
     }
   },
   methods: {
     versionChange(version) {
       // vue router won't work because of the generated path prefix in makefile
-      // this.$router.push({ path: `/${version.key}` }, () => {})
+      // this.$router.push({ path: `/${version}` }, () => {})
       // to fix urls with path prefixes: https://docs.staging-cosmos.network/master/master
       // window.open(`${window.location.origin}/${version}`)
       window.location.href = `${window.location.origin}/${version}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10211,6 +10211,11 @@
         "markdown-it-container": "^2.0.0"
       }
     },
+    "vuepress-plugin-google-tag-manager": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-google-tag-manager/-/vuepress-plugin-google-tag-manager-0.0.5.tgz",
+      "integrity": "sha512-Hm1GNDdNmc4Vs9c3OMfTtHicB/oZWNCmzMFPdlOObVN1OjizIjImdm+LZIwiVKVndT2TQ4BPhMx7HQkovmD2Lg=="
+    },
     "vuepress-plugin-sitemap": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/vuepress-plugin-sitemap/-/vuepress-plugin-sitemap-2.3.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-theme-cosmos",
-  "version": "1.0.178",
+  "version": "1.0.179",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-theme-cosmos",
-  "version": "1.0.178",
+  "version": "1.0.179",
   "description": "Theme for VuePress static site generator used by Tendermint and Cosmos projects.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "tiny-cookie": "^2.3.2",
     "v-runtime-template": "^1.10.0",
     "vuepress": "^1.5.4",
+    "vuepress-plugin-google-tag-manager": "0.0.5",
     "vuepress-plugin-sitemap": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes: https://github.com/cosmos/vuepress-theme-cosmos/issues/175

![image](https://user-images.githubusercontent.com/1021101/101675025-115a0f00-3a0e-11eb-9c2d-b1a2871a1426.png)
![image](https://user-images.githubusercontent.com/1021101/101675035-1454ff80-3a0e-11eb-8b7b-46f34df2e889.png)


## Description

- GTM
- Versions → Version
- Cross browser select option ui
- Shows version number on version switcher according to the URL
- Automatically extracts the version number from these URLs: http://docs.cosmos.network/, http://docs.cosmos.network/master, https://docs.cosmos.network/v0.39/intro/overview.html 

______

For contributor use:

- [ ] Linked to relevant Github issues
- [ ] Provided a description
- [ ] Added a relevant changelog
- [ ] Re-reviewed `Files changed`

______

For admin use:

- [x] Checked errors / warnings on console
- [x] Ran `npm run build` in the local dev repo to make sure it compiles without any errors
- [x] When bumping version, made sure `package-lock.json` has the latest version
