### PR TITLE
remove trailing slash when extracting version from url

### DIFF
--- a/global-components/TmSelectVersion.vue
+++ b/global-components/TmSelectVersion.vue
@@ -17,24 +17,28 @@ export default {
   },
   mounted() {
     const emptyVal = ""
-    const pathName = window.location.pathname.replace("/", "")
+    // #91: remove trailing slash to fix cloudfront, netlify, gh-pages's deployed URLs
+    const pathName = window.location.pathname.replace("/", "").replace(/\/$/, "")
     const pathRe = /[a-zA-Z]{1}\d+(\.\d+)+/g
     const versionPathName = window.location.href.match(pathRe)
 
     // match values in select option
-    // e.g. http://docs.cosmos.network/master
+    // input: https://docs.cosmos.network/master
+    // output: null
     if (this.versionValue === this.versionValue) {
       // check if input has a pathname
       // extract version number from string
       // point to the selectedItem
-      // e.g. https://docs.cosmos.network/v0.39/intro/overview.html
+      // input: https://docs.cosmos.network/v0.39/intro/overview.html
+      // output: [ 'v0.39' ]
       if (versionPathName !== null) {
         this.selectedItem = versionPathName[0]
       } else {
         this.selectedItem = pathName
       }
     }
-    // e.g. http://docs.cosmos.network
+    // input: http://docs.cosmos.network
+    // expected: 'Version'
     else {
       this.selectedItem = emptyVal
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-theme-cosmos",
-  "version": "1.0.179",
+  "version": "1.0.180",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-theme-cosmos",
-  "version": "1.0.179",
+  "version": "1.0.180",
   "description": "Theme for VuePress static site generator used by Tendermint and Cosmos projects.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Related: https://github.com/cosmos/vuepress-theme-cosmos/issues/91#issuecomment-761234735

## Description

______

For contributor use:

- [ ] Linked to relevant Github issues
- [ ] Provided a description
- [ ] Added a relevant changelog
- [ ] Re-reviewed `Files changed`

______

For admin use:

- [ ] Checked errors / warnings on console
- [ ] Ran `npm run build` in the local dev repo to make sure it compiles without any errors
- [ ] When bumping version, made sure `package-lock.json` has the latest version
