### PR TITLE
docs: add scripts in package json

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,16 +25,25 @@ module.exports = {
 };
 ```
 
+Modify `scripts` property in `package.json`:
+
+```js
+  "scripts": {
+    "serve": "vuepress dev",
+    "build": "vuepress build"
+  },
+```
+
 ### Run dev server
 
 ```sh
-vupress dev
+npm run serve
 ```
 
 ### Build the website
 
 ```
-vuepress build
+npm run build
 ```
 
 ## Configuration


### PR DESCRIPTION
Replaced `vuepress dev` and `build` with `npm` scripts, because to run `vuepress` commands you need to install it globally. Even though it adds additional couple of lines of config, t may be better to use a local copy of Vuepress.