### PR TITLE
update ibc link to point to docs instead of protocol site

### DIFF
--- a/global-components/TmSidebarContent.vue
+++ b/global-components/TmSidebarContent.vue
@@ -182,8 +182,8 @@ export default {
         },
         {
           label: "ibc",
-          name: "IBC<br>Protocol",
-          url: "https://ibcprotocol.org",
+          name: "IBC<br>Go",
+          url: "https://ibc.cosmos.network",
           color: "#E6900A",
         },
         {

--- a/readme.md
+++ b/readme.md
@@ -225,6 +225,7 @@ https://github.com/cosmos/cosmos-sdk/blob/master/Makefile#L195 to build versione
 5. [Kava Documentation](https://docs.kava.io) — [`github`](https://github.com/Kava-Labs/kava/tree/master/docs) — [`.vuepress/config.js`](https://github.com/Kava-Labs/kava/blob/master/docs/.vuepress/config.js)
 6. [Ethermint Documentation](https://docs.ethermint.zone) — [`github`](https://github.com/ChainSafe/ethermint/tree/development/docs) — [`.vuepress/config.js`](https://github.com/ChainSafe/ethermint/blob/development/docs/.vuepress/config.js)
 7. [Cosmwasm Documentation](https://docs.cosmwasm.com) — [`github`](https://github.com/CosmWasm/docs2) — [`.vuepress/config.js`](https://github.com/CosmWasm/docs2/blob/master/.vuepress/config.js)
+8. [IBC-Go Documentation](https://ibc.cosmos.network) — [`github`](https://github.com/cosmos/ibc-go/tree/main/docs) — [`.vuepress/config.js`](https://github.com/cosmos/ibc-go/blob/main/docs/.vuepress/config.js)
 
 ## Contributing
 


### PR DESCRIPTION
It changes the IBC link on the bottom left sidebar to point to the [docs website](https://ibc.cosmos.network) instead of the protocol site. Also adds IBC-Go to the list of docs site that uses the theme.

Closes: 

<!-- Description -->
<!-- Relevant changelog -->

Related:

## Description

______

For contributor use:

- [ ] Linked to relevant Github issues
- [x] Provided a description
- [ ] Added a relevant changelog
- [x] Re-reviewed `Files changed`

______

For admin use:

- [ ] Checked errors / warnings on console
- [ ] Ran `npm run build` in the local dev repo to make sure it compiles without any errors
- [ ] When bumping version, made sure `package-lock.json` has the latest version
